### PR TITLE
Add session ext

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -12,10 +12,10 @@ servers that operate on remote machines and clients that talk to them.
 
 - Asynchronous in nature, powered by [`tokio`](https://tokio.rs/)
 - Data is serialized to send across the wire via [`CBOR`](https://cbor.io/)
-- Encryption & authentication are handled via [`orion`](https://crates.io/crates/orion)
-    - [XChaCha20Poly1305](https://cryptopp.com/wiki/XChaCha20Poly1305) for an authenticated encryption scheme
-    - [BLAKE2b-256](https://www.blake2.net/) in keyed mode for a second authentication
-    - [Elliptic Curve Diffie-Hellman](https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman) (ECDH) for key exchange
+- Encryption & authentication are handled via
+  [XChaCha20Poly1305](https://tools.ietf.org/html/rfc8439) for an authenticated
+  encryption scheme via
+  [RustCrypto/ChaCha20Poly1305](https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305)
 
 ## Installation
 

--- a/core/src/client/process.rs
+++ b/core/src/client/process.rs
@@ -1,8 +1,8 @@
 use crate::{
-    client::Session,
-    constants::CLIENT_BROADCAST_CHANNEL_CAPACITY,
-    data::{Request, RequestData, Response, ResponseData},
-    net::{Codec, DataStream, TransportError},
+    client::{Mailbox, Session, SessionSender},
+    constants::CLIENT_MAILBOX_CAPACITY,
+    data::{Request, RequestData, ResponseData},
+    net::TransportError,
 };
 use derive_more::{Display, Error, From};
 use log::*;
@@ -14,9 +14,6 @@ use tokio::{
 
 #[derive(Debug, Display, Error, From)]
 pub enum RemoteProcessError {
-    /// When the process receives an unexpected response
-    BadResponse,
-
     /// When attempting to relay stdout/stderr over channels, but the channels fail
     ChannelDead,
 
@@ -36,6 +33,9 @@ pub enum RemoteProcessError {
 pub struct RemoteProcess {
     /// Id of the process
     id: usize,
+
+    /// Id used to map back to mailbox
+    pub(crate) origin_id: usize,
 
     /// Task that forwards stdin to the remote process by bundling it as stdin requests
     req_task: JoinHandle<Result<(), RemoteProcessError>>,
@@ -59,39 +59,54 @@ pub struct RemoteProcess {
 
 impl RemoteProcess {
     /// Spawns the specified process on the remote machine using the given session
-    pub async fn spawn<T, U>(
-        tenant: String,
-        mut session: Session<T, U>,
-        cmd: String,
+    pub async fn spawn(
+        tenant: impl Into<String>,
+        session: &mut Session,
+        cmd: impl Into<String>,
         args: Vec<String>,
-    ) -> Result<Self, RemoteProcessError>
-    where
-        T: DataStream + 'static,
-        U: Codec + Send + 'static,
-    {
-        // Submit our run request and wait for a response
-        let res = session
-            .send(Request::new(
+    ) -> Result<Self, TransportError> {
+        let tenant = tenant.into();
+        let cmd = cmd.into();
+
+        // Submit our run request and get back a mailbox for responses
+        let mailbox = session
+            .mail(Request::new(
                 tenant.as_str(),
                 vec![RequestData::ProcRun { cmd, args }],
             ))
             .await?;
 
-        // We expect a singular response back
-        if res.payload.len() != 1 {
-            return Err(RemoteProcessError::BadResponse);
-        }
-
-        // Response should be proc starting
-        let id = match res.payload.into_iter().next().unwrap() {
-            ResponseData::ProcStart { id } => id,
-            _ => return Err(RemoteProcessError::BadResponse),
+        // Wait until we get the first response, and get id from proc started
+        let (id, origin_id) = match mailbox.next().await {
+            Some(res) if res.payload.len() != 1 => {
+                return Err(TransportError::IoError(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Got wrong payload size",
+                )));
+            }
+            Some(res) => {
+                let origin_id = res.origin_id;
+                match res.payload.into_iter().next().unwrap() {
+                    ResponseData::ProcStart { id } => (id, origin_id),
+                    x => {
+                        return Err(TransportError::IoError(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Got response type of {}", x.as_ref()),
+                        )))
+                    }
+                }
+            }
+            None => {
+                return Err(TransportError::IoError(io::Error::from(
+                    io::ErrorKind::ConnectionAborted,
+                )))
+            }
         };
 
         // Create channels for our stdin/stdout/stderr
-        let (stdin_tx, stdin_rx) = mpsc::channel(CLIENT_BROADCAST_CHANNEL_CAPACITY);
-        let (stdout_tx, stdout_rx) = mpsc::channel(CLIENT_BROADCAST_CHANNEL_CAPACITY);
-        let (stderr_tx, stderr_rx) = mpsc::channel(CLIENT_BROADCAST_CHANNEL_CAPACITY);
+        let (stdin_tx, stdin_rx) = mpsc::channel(CLIENT_MAILBOX_CAPACITY);
+        let (stdout_tx, stdout_rx) = mpsc::channel(CLIENT_MAILBOX_CAPACITY);
+        let (stderr_tx, stderr_rx) = mpsc::channel(CLIENT_MAILBOX_CAPACITY);
 
         // Used to terminate request task, either explicitly by the process or internally
         // by the response task when it terminates
@@ -100,18 +115,19 @@ impl RemoteProcess {
         // Now we spawn a task to handle future responses that are async
         // such as ProcStdout, ProcStderr, and ProcDone
         let kill_tx_2 = kill_tx.clone();
-        let broadcast = session.broadcast.take().unwrap();
         let res_task = tokio::spawn(async move {
-            process_incoming_responses(id, broadcast, stdout_tx, stderr_tx, kill_tx_2).await
+            process_incoming_responses(id, mailbox, stdout_tx, stderr_tx, kill_tx_2).await
         });
 
         // Spawn a task that takes stdin from our channel and forwards it to the remote process
+        let sender = session.clone_sender();
         let req_task = tokio::spawn(async move {
-            process_outgoing_requests(tenant, id, session, stdin_rx, kill_rx).await
+            process_outgoing_requests(tenant, id, sender, stdin_rx, kill_rx).await
         });
 
         Ok(Self {
             id,
+            origin_id,
             req_task,
             res_task,
             stdin: Some(RemoteStdin(stdin_tx)),
@@ -196,22 +212,18 @@ impl RemoteStderr {
 
 /// Helper function that loops, processing outgoing stdin requests to a remote process as well as
 /// supporting a kill request to terminate the remote process
-async fn process_outgoing_requests<T, U>(
+async fn process_outgoing_requests(
     tenant: String,
     id: usize,
-    mut session: Session<T, U>,
+    mut sender: SessionSender,
     mut stdin_rx: mpsc::Receiver<String>,
     mut kill_rx: mpsc::Receiver<()>,
-) -> Result<(), RemoteProcessError>
-where
-    T: DataStream,
-    U: Codec,
-{
+) -> Result<(), RemoteProcessError> {
     let result = loop {
         tokio::select! {
             data = stdin_rx.recv() => {
                 match data {
-                    Some(data) => session.fire(
+                    Some(data) => sender.fire(
                         Request::new(
                             tenant.as_str(),
                             vec![RequestData::ProcStdin { id, data }]
@@ -222,12 +234,10 @@ where
             }
             msg = kill_rx.recv() => {
                 if msg.is_some() {
-                    session
-                        .fire(Request::new(
-                            tenant.as_str(),
-                            vec![RequestData::ProcKill { id }],
-                        ))
-                        .await?;
+                    sender.fire(Request::new(
+                        tenant.as_str(),
+                        vec![RequestData::ProcKill { id }],
+                    )).await?;
                     break Ok(());
                 } else {
                     break Err(RemoteProcessError::ChannelDead);
@@ -243,12 +253,12 @@ where
 /// Helper function that loops, processing incoming stdout & stderr requests from a remote process
 async fn process_incoming_responses(
     proc_id: usize,
-    mut broadcast: mpsc::Receiver<Response>,
+    mailbox: Mailbox,
     stdout_tx: mpsc::Sender<String>,
     stderr_tx: mpsc::Sender<String>,
     kill_tx: mpsc::Sender<()>,
 ) -> Result<(bool, Option<i32>), RemoteProcessError> {
-    while let Some(res) = broadcast.recv().await {
+    while let Some(res) = mailbox.next().await {
         // Check if any of the payload data is the termination
         let exit_status = res.payload.iter().find_map(|data| match data {
             ResponseData::ProcDone { id, success, code } if *id == proc_id => {
@@ -291,61 +301,67 @@ async fn process_incoming_responses(
 mod tests {
     use super::*;
     use crate::{
-        data::{Error, ErrorKind},
+        data::{Error, ErrorKind, Response},
         net::{InmemoryStream, PlainCodec, Transport},
     };
 
-    fn make_session() -> (
-        Transport<InmemoryStream, PlainCodec>,
-        Session<InmemoryStream, PlainCodec>,
-    ) {
+    fn make_session() -> (Transport<InmemoryStream, PlainCodec>, Session) {
         let (t1, t2) = Transport::make_pair();
         (t1, Session::initialize(t2).unwrap())
     }
 
     #[tokio::test]
-    async fn spawn_should_return_bad_response_if_payload_size_unexpected() {
-        let (mut transport, session) = make_session();
+    async fn spawn_should_return_invalid_data_if_payload_size_unexpected() {
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
 
         // Send back a response through the session
         transport
-            .send(Response::new("test-tenant", Some(req.id), Vec::new()))
+            .send(Response::new("test-tenant", req.id, Vec::new()))
             .await
             .unwrap();
 
         // Get the spawn result and verify
         let result = spawn_task.await.unwrap();
         assert!(
-            matches!(result, Err(RemoteProcessError::BadResponse)),
+            matches!(
+                &result,
+                Err(TransportError::IoError(x)) if x.kind() == io::ErrorKind::InvalidData
+            ),
             "Unexpected result: {:?}",
             result
         );
     }
 
     #[tokio::test]
-    async fn spawn_should_return_bad_response_if_did_not_get_a_indicator_that_process_started() {
-        let (mut transport, session) = make_session();
+    async fn spawn_should_return_invalid_data_if_did_not_get_a_indicator_that_process_started() {
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -354,7 +370,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::Error(Error {
                     kind: ErrorKind::Other,
                     description: String::from("some error"),
@@ -366,7 +382,10 @@ mod tests {
         // Get the spawn result and verify
         let result = spawn_task.await.unwrap();
         assert!(
-            matches!(result, Err(RemoteProcessError::BadResponse)),
+            matches!(
+                &result,
+                Err(TransportError::IoError(x)) if x.kind() == io::ErrorKind::InvalidData
+            ),
             "Unexpected result: {:?}",
             result
         );
@@ -374,16 +393,19 @@ mod tests {
 
     #[tokio::test]
     async fn kill_should_return_error_if_internal_tasks_already_completed() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -393,7 +415,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -416,16 +438,19 @@ mod tests {
 
     #[tokio::test]
     async fn kill_should_send_proc_kill_request_and_then_cause_stdin_forwarding_to_close() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -435,7 +460,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -469,16 +494,19 @@ mod tests {
 
     #[tokio::test]
     async fn stdin_should_be_forwarded_from_receiver_field() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -488,7 +516,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -521,16 +549,19 @@ mod tests {
 
     #[tokio::test]
     async fn stdout_should_be_forwarded_to_receiver_field() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -540,7 +571,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -552,7 +583,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                None,
+                req.id,
                 vec![ResponseData::ProcStdout {
                     id,
                     data: String::from("some out"),
@@ -567,16 +598,19 @@ mod tests {
 
     #[tokio::test]
     async fn stderr_should_be_forwarded_to_receiver_field() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -586,7 +620,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -598,7 +632,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                None,
+                req.id,
                 vec![ResponseData::ProcStderr {
                     id,
                     data: String::from("some err"),
@@ -613,16 +647,19 @@ mod tests {
 
     #[tokio::test]
     async fn wait_should_return_error_if_internal_tasks_fail() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -632,7 +669,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -652,16 +689,19 @@ mod tests {
 
     #[tokio::test]
     async fn wait_should_return_error_if_connection_terminates_before_receiving_done_response() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -671,7 +711,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -694,16 +734,19 @@ mod tests {
 
     #[tokio::test]
     async fn receiving_done_response_should_result_in_wait_returning_exit_information() {
-        let (mut transport, session) = make_session();
+        let (mut transport, mut session) = make_session();
 
         // Create a task for process spawning as we need to handle the request and a response
         // in a separate async block
-        let spawn_task = tokio::spawn(RemoteProcess::spawn(
-            String::from("test-tenant"),
-            session,
-            String::from("cmd"),
-            vec![String::from("arg")],
-        ));
+        let spawn_task = tokio::spawn(async move {
+            RemoteProcess::spawn(
+                String::from("test-tenant"),
+                &mut session,
+                String::from("cmd"),
+                vec![String::from("arg")],
+            )
+            .await
+        });
 
         // Wait until we get the request from the session
         let req = transport.receive::<Request>().await.unwrap().unwrap();
@@ -713,7 +756,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                Some(req.id),
+                req.id,
                 vec![ResponseData::ProcStart { id }],
             ))
             .await
@@ -727,7 +770,7 @@ mod tests {
         transport
             .send(Response::new(
                 "test-tenant",
-                None,
+                req.id,
                 vec![ResponseData::ProcDone {
                     id,
                     success: false,

--- a/core/src/client/session/ext.rs
+++ b/core/src/client/session/ext.rs
@@ -1,0 +1,438 @@
+use crate::{
+    client::{RemoteProcess, Session},
+    data::{DirEntry, Error as Failure, FileType, Request, RequestData, ResponseData},
+    net::TransportError,
+};
+use derive_more::{Display, Error, From};
+use std::{future::Future, path::PathBuf, pin::Pin};
+
+/// Represents an error that can occur related to convenience functions tied to a [`Session`]
+#[derive(Debug, Display, Error, From)]
+pub enum SessionExtError {
+    /// Occurs when the remote action fails
+    Failure(#[error(not(source))] Failure),
+
+    /// Occurs when a transport error is encountered
+    TransportError(TransportError),
+
+    /// Occurs when receiving a response that was not expected
+    MismatchedResponse,
+}
+
+pub type AsyncReturn<'a, T> = Pin<Box<dyn Future<Output = Result<T, SessionExtError>> + Send + 'a>>;
+
+/// Represents metadata about some path on a remote machine
+pub struct Metadata {
+    pub file_type: FileType,
+    pub len: u64,
+    pub readonly: bool,
+
+    pub canonicalized_path: Option<PathBuf>,
+
+    pub accessed: Option<u128>,
+    pub created: Option<u128>,
+    pub modified: Option<u128>,
+}
+
+/// Provides convenience functions on top of a [`Session`]
+pub trait SessionExt {
+    /// Appends to a remote file using the data from a collection of bytes
+    fn append_file(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<Vec<u8>>,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Appends to a remote file using the data from a string
+    fn append_file_text(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<String>,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Copies a remote file or directory from src to dst
+    fn copy(
+        &mut self,
+        tenant: impl Into<String>,
+        src: impl Into<PathBuf>,
+        dst: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Creates a remote directory, optionally creating all parent components if specified
+    fn create_dir(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        all: bool,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Checks if a path exists on a remote machine
+    fn exists(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, bool>;
+
+    /// Retrieves metadata about a path on a remote machine
+    fn metadata(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        canonicalize: bool,
+        resolve_file_type: bool,
+    ) -> AsyncReturn<'_, Metadata>;
+
+    /// Reads entries from a directory, returning a tuple of directory entries and failures
+    fn read_dir(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        depth: usize,
+        absolute: bool,
+        canonicalize: bool,
+        include_root: bool,
+    ) -> AsyncReturn<'_, (Vec<DirEntry>, Vec<Failure>)>;
+
+    /// Reads a remote file as a collection of bytes
+    fn read_file(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, Vec<u8>>;
+
+    /// Returns a remote file as a string
+    fn read_file_text(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, String>;
+
+    /// Removes a remote file or directory, supporting removal of non-empty directories if
+    /// force is true
+    fn remove(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        force: bool,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Renames a remote file or directory from src to dst
+    fn rename(
+        &mut self,
+        tenant: impl Into<String>,
+        src: impl Into<PathBuf>,
+        dst: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Spawns a process on the remote machine
+    fn spawn(
+        &mut self,
+        tenant: impl Into<String>,
+        cmd: impl Into<String>,
+        args: Vec<String>,
+    ) -> AsyncReturn<'_, RemoteProcess>;
+
+    /// Writes a remote file with the data from a collection of bytes
+    fn write_file(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<Vec<u8>>,
+    ) -> AsyncReturn<'_, ()>;
+
+    /// Writes a remote file with the data from a string
+    fn write_file_text(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<String>,
+    ) -> AsyncReturn<'_, ()>;
+}
+
+macro_rules! make_body {
+    ($self:expr, $tenant:expr, $data:expr, @ok) => {
+        make_body!($self, $tenant, $data, |data| {
+            if data.is_ok() {
+                Ok(())
+            } else {
+                Err(SessionExtError::MismatchedResponse)
+            }
+        })
+    };
+
+    ($self:expr, $tenant:expr, $data:expr, $and_then:expr) => {{
+        let req = Request::new($tenant, vec![$data]);
+        Box::pin(async move {
+            $self
+                .send(req)
+                .await
+                .map_err(SessionExtError::from)
+                .and_then(|res| {
+                    if res.payload.len() == 1 {
+                        Ok(res.payload.into_iter().next().unwrap())
+                    } else {
+                        Err(SessionExtError::MismatchedResponse)
+                    }
+                })
+                .and_then($and_then)
+        })
+    }};
+}
+
+impl SessionExt for Session {
+    /// Appends to a remote file using the data from a collection of bytes
+    fn append_file(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<Vec<u8>>,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::FileAppend { path: path.into(), data: data.into() },
+            @ok
+        )
+    }
+
+    /// Appends to a remote file using the data from a string
+    fn append_file_text(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<String>,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::FileAppendText { path: path.into(), text: data.into() },
+            @ok
+        )
+    }
+
+    /// Copies a remote file or directory from src to dst
+    fn copy(
+        &mut self,
+        tenant: impl Into<String>,
+        src: impl Into<PathBuf>,
+        dst: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::Copy { src: src.into(), dst: dst.into() },
+            @ok
+        )
+    }
+
+    /// Creates a remote directory, optionally creating all parent components if specified
+    fn create_dir(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        all: bool,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::DirCreate { path: path.into(), all },
+            @ok
+        )
+    }
+
+    /// Checks if a path exists on a remote machine
+    fn exists(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, bool> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::Exists { path: path.into() },
+            |data| match data {
+                ResponseData::Exists(x) => Ok(x),
+                _ => Err(SessionExtError::MismatchedResponse),
+            }
+        )
+    }
+
+    /// Retrieves metadata about a path on a remote machine
+    fn metadata(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        canonicalize: bool,
+        resolve_file_type: bool,
+    ) -> AsyncReturn<'_, Metadata> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::Metadata {
+                path: path.into(),
+                canonicalize,
+                resolve_file_type
+            },
+            |data| match data {
+                ResponseData::Metadata {
+                    canonicalized_path,
+                    file_type,
+                    len,
+                    readonly,
+                    accessed,
+                    created,
+                    modified,
+                } => Ok(Metadata {
+                    canonicalized_path,
+                    file_type,
+                    len,
+                    readonly,
+                    accessed,
+                    created,
+                    modified,
+                }),
+                _ => Err(SessionExtError::MismatchedResponse),
+            }
+        )
+    }
+
+    /// Reads entries from a directory, returning a tuple of directory entries and failures
+    fn read_dir(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        depth: usize,
+        absolute: bool,
+        canonicalize: bool,
+        include_root: bool,
+    ) -> AsyncReturn<'_, (Vec<DirEntry>, Vec<Failure>)> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::DirRead {
+                path: path.into(),
+                depth,
+                absolute,
+                canonicalize,
+                include_root
+            },
+            |data| match data {
+                ResponseData::DirEntries { entries, errors } => Ok((entries, errors)),
+                _ => Err(SessionExtError::MismatchedResponse),
+            }
+        )
+    }
+
+    /// Reads a remote file as a collection of bytes
+    fn read_file(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, Vec<u8>> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::FileRead { path: path.into() },
+            |data| match data {
+                ResponseData::Blob { data } => Ok(data),
+                _ => Err(SessionExtError::MismatchedResponse),
+            }
+        )
+    }
+
+    /// Returns a remote file as a string
+    fn read_file_text(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, String> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::FileReadText { path: path.into() },
+            |data| match data {
+                ResponseData::Text { data } => Ok(data),
+                _ => Err(SessionExtError::MismatchedResponse),
+            }
+        )
+    }
+
+    /// Removes a remote file or directory, supporting removal of non-empty directories if
+    /// force is true
+    fn remove(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        force: bool,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::Remove { path: path.into(), force },
+            @ok
+        )
+    }
+
+    /// Renames a remote file or directory from src to dst
+    fn rename(
+        &mut self,
+        tenant: impl Into<String>,
+        src: impl Into<PathBuf>,
+        dst: impl Into<PathBuf>,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::Rename { src: src.into(), dst: dst.into() },
+            @ok
+        )
+    }
+
+    /// Spawns a process on the remote machine
+    fn spawn(
+        &mut self,
+        tenant: impl Into<String>,
+        cmd: impl Into<String>,
+        args: Vec<String>,
+    ) -> AsyncReturn<'_, RemoteProcess> {
+        let tenant = tenant.into();
+        let cmd = cmd.into();
+        Box::pin(async move {
+            RemoteProcess::spawn(tenant, self, cmd, args)
+                .await
+                .map_err(SessionExtError::from)
+        })
+    }
+
+    /// Writes a remote file with the data from a collection of bytes
+    fn write_file(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<Vec<u8>>,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::FileWrite { path: path.into(), data: data.into() },
+            @ok
+        )
+    }
+
+    /// Writes a remote file with the data from a string
+    fn write_file_text(
+        &mut self,
+        tenant: impl Into<String>,
+        path: impl Into<PathBuf>,
+        data: impl Into<String>,
+    ) -> AsyncReturn<'_, ()> {
+        make_body!(
+            self,
+            tenant,
+            RequestData::FileWriteText { path: path.into(), text: data.into() },
+            @ok
+        )
+    }
+}

--- a/core/src/client/session/mailbox.rs
+++ b/core/src/client/session/mailbox.rs
@@ -1,6 +1,9 @@
-use crate::data::Response;
-use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{mpsc, Mutex};
+use crate::{client::utils, data::Response};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{
+    io,
+    sync::{mpsc, Mutex},
+};
 
 pub struct PostOffice {
     mailboxes: HashMap<usize, mpsc::Sender<Response>>,
@@ -72,5 +75,10 @@ impl Mailbox {
     /// Receives next response in mailbox
     pub async fn next(&self) -> Option<Response> {
         self.rx.lock().await.recv().await
+    }
+
+    /// Receives next response in mailbox, waiting up to duration before timing out
+    pub async fn next_timeout(&self, duration: Duration) -> io::Result<Option<Response>> {
+        utils::timeout(duration, self.next()).await
     }
 }

--- a/core/src/client/session/mailbox.rs
+++ b/core/src/client/session/mailbox.rs
@@ -1,0 +1,76 @@
+use crate::data::Response;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{mpsc, Mutex};
+
+pub struct PostOffice {
+    mailboxes: HashMap<usize, mpsc::Sender<Response>>,
+}
+
+impl PostOffice {
+    pub fn new() -> Self {
+        Self {
+            mailboxes: HashMap::new(),
+        }
+    }
+
+    /// Creates a new mailbox using the given id and buffer size for maximum messages
+    pub fn make_mailbox(&mut self, id: usize, buffer: usize) -> Mailbox {
+        let (tx, rx) = mpsc::channel(buffer);
+        self.mailboxes.insert(id, tx);
+
+        Mailbox {
+            id,
+            rx: Arc::new(Mutex::new(rx)),
+        }
+    }
+
+    /// Delivers a response to appropriate mailbox, returning false if no mailbox is found
+    /// for the response or if the mailbox is no longer receiving responses
+    pub async fn deliver(&mut self, res: Response) -> bool {
+        let id = res.origin_id;
+
+        let success = if let Some(tx) = self.mailboxes.get_mut(&id) {
+            tx.send(res).await.is_ok()
+        } else {
+            false
+        };
+
+        // If failed, we want to remvoe the mailbox sender as it is no longer valid
+        if !success {
+            self.mailboxes.remove(&id);
+        }
+
+        success
+    }
+
+    /// Removes all mailboxes from post office that are closed
+    pub fn prune_mailboxes(&mut self) {
+        self.mailboxes.retain(|_, tx| !tx.is_closed())
+    }
+
+    /// Closes out all mailboxes by removing the mailboxes delivery trackers internally
+    pub fn close_mailboxes(&mut self) {
+        self.mailboxes.clear();
+    }
+}
+
+#[derive(Clone)]
+pub struct Mailbox {
+    /// Represents id associated with the mailbox
+    id: usize,
+
+    /// Underlying mailbox storage
+    rx: Arc<Mutex<mpsc::Receiver<Response>>>,
+}
+
+impl Mailbox {
+    /// Represents id associated with the mailbox
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    /// Receives next response in mailbox
+    pub async fn next(&self) -> Option<Response> {
+        self.rx.lock().await.recv().await
+    }
+}

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,6 +1,5 @@
-/// Capacity associated with a client broadcasting its received messages that
-/// do not have a callback associated
-pub const CLIENT_BROADCAST_CHANNEL_CAPACITY: usize = 10000;
+/// Capacity associated with a client mailboxes for receiving multiple responses to a request
+pub const CLIENT_MAILBOX_CAPACITY: usize = 10000;
 
 /// Represents the maximum size (in bytes) that data will be read from pipes
 /// per individual `read` call

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -257,9 +257,9 @@ pub struct Response {
     /// A unique id associated with the response
     pub id: usize,
 
-    /// The id of the originating request, if there was one
-    /// (some responses are sent unprompted)
-    pub origin_id: Option<usize>,
+    /// The id of the originating request that yielded this response
+    /// (more than one response may have same origin)
+    pub origin_id: usize,
 
     /// The main payload containing a collection of data comprising one or more results
     pub payload: Vec<ResponseData>,
@@ -267,11 +267,7 @@ pub struct Response {
 
 impl Response {
     /// Creates a new response, generating a unique id for it
-    pub fn new(
-        tenant: impl Into<String>,
-        origin_id: Option<usize>,
-        payload: Vec<ResponseData>,
-    ) -> Self {
+    pub fn new(tenant: impl Into<String>, origin_id: usize, payload: Vec<ResponseData>) -> Self {
         let id = rand::random();
         Self {
             tenant: tenant.into(),
@@ -486,7 +482,8 @@ impl From<tokio::task::JoinError> for ResponseData {
 }
 
 /// General purpose error type that can be sent across the wire
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Display, PartialEq, Eq, Serialize, Deserialize)]
+#[display(fmt = "{}: {}", kind, description)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct Error {
     /// Label describing the kind of error

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,9 +1,9 @@
 mod client;
 pub use client::{
     LspContent, LspContentParseError, LspData, LspDataParseError, LspHeader, LspHeaderParseError,
-    LspSessionInfoError, RemoteLspProcess, RemoteLspStderr, RemoteLspStdin, RemoteLspStdout,
-    RemoteProcess, RemoteProcessError, RemoteStderr, RemoteStdin, RemoteStdout, Session,
-    SessionInfo, SessionInfoFile, SessionInfoParseError,
+    LspSessionInfoError, Mailbox, RemoteLspProcess, RemoteLspStderr, RemoteLspStdin,
+    RemoteLspStdout, RemoteProcess, RemoteProcessError, RemoteStderr, RemoteStdin, RemoteStdout,
+    Session, SessionInfo, SessionInfoFile, SessionInfoParseError,
 };
 
 mod constants;

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -106,12 +106,11 @@ impl ExitCodeError for TransportError {
 
 impl ExitCodeError for RemoteProcessError {
     fn is_silent(&self) -> bool {
-        matches!(self, Self::BadResponse)
+        true
     }
 
     fn to_exit_code(&self) -> ExitCode {
         match self {
-            Self::BadResponse => ExitCode::DataErr,
             Self::ChannelDead => ExitCode::Unavailable,
             Self::TransportError(x) => x.to_exit_code(),
             Self::UnexpectedEof => ExitCode::IoError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,15 +38,7 @@ fn init_logging(opt: &opt::CommonOpt, is_remote_process: bool) -> flexi_logger::
 
     // For each module, configure logging
     for module in modules {
-        builder.module(
-            module,
-            match opt.verbose {
-                0 => LevelFilter::Warn,
-                1 => LevelFilter::Info,
-                2 => LevelFilter::Debug,
-                _ => LevelFilter::Trace,
-            },
-        );
+        builder.module(module, opt.log_level.to_log_level_filter());
 
         // If quiet, we suppress all logging output
         //

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -84,8 +84,8 @@ pub struct CommonOpt {
 
     /// Log level to use throughout the application
     #[structopt(
-        long, 
-        global = true, 
+        long,
+        global = true,
         case_insensitive = true,
         default_value = LogLevel::Info.into(),
         possible_values = LogLevel::VARIANTS

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -40,16 +40,57 @@ impl Opt {
     }
 }
 
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Display,
+    PartialEq,
+    Eq,
+    IsVariant,
+    IntoStaticStr,
+    EnumString,
+    EnumVariantNames,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    pub fn to_log_level_filter(self) -> log::LevelFilter {
+        match self {
+            Self::Off => log::LevelFilter::Off,
+            Self::Error => log::LevelFilter::Error,
+            Self::Warn => log::LevelFilter::Warn,
+            Self::Info => log::LevelFilter::Info,
+            Self::Debug => log::LevelFilter::Debug,
+            Self::Trace => log::LevelFilter::Trace,
+        }
+    }
+}
+
 /// Contains options that are common across subcommands
 #[derive(Debug, StructOpt)]
 pub struct CommonOpt {
-    /// Verbose mode (-v, -vv, -vvv, etc.)
-    #[structopt(short, long, parse(from_occurrences), global = true)]
-    pub verbose: u8,
-
-    /// Quiet mode, suppresses all logging
+    /// Quiet mode, suppresses all logging (shortcut for log level off)
     #[structopt(short, long, global = true)]
     pub quiet: bool,
+
+    /// Log level to use throughout the application
+    #[structopt(
+        long, 
+        global = true, 
+        case_insensitive = true,
+        default_value = LogLevel::Info.into(),
+        possible_values = LogLevel::VARIANTS
+    )]
+    pub log_level: LogLevel,
 
     /// Log output to disk instead of stderr
     #[structopt(long, global = true)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,35 +1,38 @@
 use crate::{
     buf::StringBuf, constants::MAX_PIPE_CHUNK_SIZE, opt::Format, output::ResponseOut, stdin,
 };
-use distant_core::{Codec, DataStream, Request, RequestData, Response, Session};
+use distant_core::{Mailbox, Request, RequestData, Session};
 use log::*;
-use std::{io, thread};
+use std::io;
 use structopt::StructOpt;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 
 /// Represents a wrapper around a session that provides CLI functionality such as reading from
 /// stdin and piping results back out to stdout
 pub struct CliSession {
-    _stdin_thread: thread::JoinHandle<()>,
     req_task: JoinHandle<()>,
-    res_task: JoinHandle<io::Result<()>>,
 }
 
 impl CliSession {
-    pub fn new<T, U>(tenant: String, mut session: Session<T, U>, format: Format) -> Self
-    where
-        T: DataStream + 'static,
-        U: Codec + Send + 'static,
-    {
-        let (stdin_thread, stdin_rx) = stdin::spawn_channel(MAX_PIPE_CHUNK_SIZE);
+    /// Creates a new instance of a session for use in CLI interactions being fed input using
+    /// the program's stdin
+    pub fn new_for_stdin(tenant: String, session: Session, format: Format) -> Self {
+        let (_stdin_thread, stdin_rx) = stdin::spawn_channel(MAX_PIPE_CHUNK_SIZE);
 
-        let (exit_tx, exit_rx) = mpsc::channel(1);
-        let broadcast = session.broadcast.take().unwrap();
-        let res_task =
-            tokio::spawn(
-                async move { process_incoming_responses(broadcast, format, exit_rx).await },
-            );
+        Self::new(tenant, session, format, stdin_rx)
+    }
 
+    /// Creates a new instance of a session for use in CLI interactions being fed input using
+    /// the provided receiver
+    pub fn new(
+        tenant: String,
+        session: Session,
+        format: Format,
+        stdin_rx: mpsc::Receiver<String>,
+    ) -> Self {
         let map_line = move |line: &str| match format {
             Format::Json => serde_json::from_str(line)
                 .map_err(|x| io::Error::new(io::ErrorKind::InvalidInput, x)),
@@ -44,20 +47,16 @@ impl CliSession {
             }
         };
         let req_task = tokio::spawn(async move {
-            process_outgoing_requests(session, stdin_rx, exit_tx, format, map_line).await
+            process_outgoing_requests(session, stdin_rx, format, map_line).await
         });
 
-        Self {
-            _stdin_thread: stdin_thread,
-            req_task,
-            res_task,
-        }
+        Self { req_task }
     }
 
     /// Wait for the cli session to terminate
     pub async fn wait(self) -> io::Result<()> {
-        match tokio::try_join!(self.req_task, self.res_task) {
-            Ok((_, res)) => res,
+        match self.req_task.await {
+            Ok(res) => Ok(res),
             Err(x) => Err(io::Error::new(io::ErrorKind::BrokenPipe, x)),
         }
     }
@@ -66,20 +65,28 @@ impl CliSession {
 /// Helper function that loops, processing incoming responses not tied to a request to be sent out
 /// over stdout/stderr
 async fn process_incoming_responses(
-    mut broadcast: mpsc::Receiver<Response>,
+    mailbox: Mailbox,
     format: Format,
-    mut exit: mpsc::Receiver<()>,
-) -> io::Result<()> {
+    mut exit: watch::Receiver<bool>,
+) {
     loop {
         tokio::select! {
-            res = broadcast.recv() => {
+            res = mailbox.next() => {
                 match res {
-                    Some(res) => ResponseOut::new(format, res)?.print(),
-                    None => return Ok(()),
+                    Some(res) => match ResponseOut::new(format, res) {
+                        Ok(out) => out.print(),
+                        Err(x) => {
+                            error!("{}", x);
+                            break;
+                        }
+                    },
+                    None => break,
                 }
             }
-            _ = exit.recv() => {
-                return Ok(());
+            v = exit.changed() => {
+                if v.is_err() || *exit.borrow() {
+                    break;
+                }
             }
         }
     }
@@ -87,18 +94,16 @@ async fn process_incoming_responses(
 
 /// Helper function that loops, processing outgoing requests created from stdin, and printing out
 /// responses
-async fn process_outgoing_requests<T, U, F>(
-    mut session: Session<T, U>,
+async fn process_outgoing_requests<F>(
+    mut session: Session,
     mut stdin_rx: mpsc::Receiver<String>,
-    exit_tx: mpsc::Sender<()>,
     format: Format,
     map_line: F,
 ) where
-    T: DataStream,
-    U: Codec,
     F: Fn(&str) -> io::Result<Request>,
 {
     let mut buf = StringBuf::new();
+    let (exit_tx, _) = watch::channel(false);
 
     while let Some(data) = stdin_rx.recv().await {
         // Update our buffer with the new data and split it into concrete lines and remainder
@@ -115,18 +120,21 @@ async fn process_outgoing_requests<T, U, F>(
                 } else if line == "exit" {
                     debug!("Got exit request, so closing cli session");
                     stdin_rx.close();
-                    if exit_tx.send(()).await.is_err() {
+                    if exit_tx.send(true).is_err() {
                         error!("Failed to close cli session");
                     }
                     continue;
                 }
 
                 match map_line(line) {
-                    Ok(req) => match session.send(req).await {
-                        Ok(res) => match ResponseOut::new(format, res) {
-                            Ok(out) => out.print(),
-                            Err(x) => error!("Failed to format response: {}", x),
-                        },
+                    Ok(req) => match session.mail(req).await {
+                        Ok(mailbox) => {
+                            tokio::spawn(process_incoming_responses(
+                                mailbox,
+                                format,
+                                exit_tx.subscribe(),
+                            ));
+                        }
                         Err(x) => {
                             error!("Failed to send request: {}", x)
                         }
@@ -138,4 +146,12 @@ async fn process_outgoing_requests<T, U, F>(
             }
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_support_
 }

--- a/src/subcommand/action.rs
+++ b/src/subcommand/action.rs
@@ -93,6 +93,12 @@ async fn start(
                 proc.stderr.take().unwrap(),
             );
 
+            // Drop main session as the singular remote process will now manage stdin/stdout/stderr
+            // NOTE: Without this, severing stdin when from this side would not occur as we would
+            //       continue to maintain a second reference to the remote connection's input
+            //       through the primary session
+            drop(session);
+
             let (success, exit_code) = proc.wait().await?;
 
             // Shut down our link

--- a/src/subcommand/action.rs
+++ b/src/subcommand/action.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use derive_more::{Display, Error, From};
 use distant_core::{
-    Codec, DataStream, LspData, RemoteProcess, RemoteProcessError, Request, RequestData, Session,
-    TransportError,
+    LspData, RemoteProcess, RemoteProcessError, Request, RequestData, Session, TransportError,
 };
 use tokio::{io, time::Duration};
 
@@ -66,23 +65,20 @@ async fn run_async(cmd: ActionSubcommand, opt: CommonOpt) -> Result<(), Error> {
     )
 }
 
-async fn start<T, U>(
+async fn start(
     cmd: ActionSubcommand,
-    mut session: Session<T, U>,
+    mut session: Session,
     timeout: Duration,
     lsp_data: Option<LspData>,
-) -> Result<(), Error>
-where
-    T: DataStream + 'static,
-    U: Codec + Send + 'static,
-{
+) -> Result<(), Error> {
     let is_shell_format = matches!(cmd.format, Format::Shell);
 
     match (cmd.interactive, cmd.operation) {
         // ProcRun request w/ shell format is specially handled and we ignore interactive as
         // the stdin will be used for sending ProcStdin to remote process
         (_, Some(RequestData::ProcRun { cmd, args })) if is_shell_format => {
-            let mut proc = RemoteProcess::spawn(utils::new_tenant(), session, cmd, args).await?;
+            let mut proc =
+                RemoteProcess::spawn(utils::new_tenant(), &mut session, cmd, args).await?;
 
             // If we also parsed an LSP's initialize request for its session, we want to forward
             // it along in the case of a process call
@@ -145,7 +141,7 @@ where
 
             // Enter into CLI session where we receive requests on stdin and send out
             // over stdout/stderr
-            let cli_session = CliSession::new(utils::new_tenant(), session, cmd.format);
+            let cli_session = CliSession::new_for_stdin(utils::new_tenant(), session, cmd.format);
             cli_session.wait().await?;
 
             Ok(())

--- a/src/subcommand/launch.rs
+++ b/src/subcommand/launch.rs
@@ -129,7 +129,7 @@ async fn keep_loop(info: SessionInfo, format: Format, duration: Duration) -> io:
     let codec = XChaCha20Poly1305Codec::from(info.key);
     match Session::tcp_connect_timeout(addr, codec, duration).await {
         Ok(session) => {
-            let cli_session = CliSession::new(utils::new_tenant(), session, format);
+            let cli_session = CliSession::new_for_stdin(utils::new_tenant(), session, format);
             cli_session.wait().await
         }
         Err(x) => Err(x),

--- a/src/subcommand/lsp.rs
+++ b/src/subcommand/lsp.rs
@@ -5,7 +5,7 @@ use crate::{
     utils,
 };
 use derive_more::{Display, Error, From};
-use distant_core::{Codec, DataStream, LspData, RemoteLspProcess, RemoteProcessError, Session};
+use distant_core::{LspData, RemoteLspProcess, RemoteProcessError, Session};
 use tokio::io;
 
 #[derive(Debug, Display, Error, From)]
@@ -53,16 +53,13 @@ async fn run_async(cmd: LspSubcommand, opt: CommonOpt) -> Result<(), Error> {
     )
 }
 
-async fn start<T, U>(
+async fn start(
     cmd: LspSubcommand,
-    session: Session<T, U>,
+    mut session: Session,
     lsp_data: Option<LspData>,
-) -> Result<(), Error>
-where
-    T: DataStream + 'static,
-    U: Codec + Send + 'static,
-{
-    let mut proc = RemoteLspProcess::spawn(utils::new_tenant(), session, cmd.cmd, cmd.args).await?;
+) -> Result<(), Error> {
+    let mut proc =
+        RemoteLspProcess::spawn(utils::new_tenant(), &mut session, cmd.cmd, cmd.args).await?;
 
     // If we also parsed an LSP's initialize request for its session, we want to forward
     // it along in the case of a process call

--- a/tests/cli/action/proc_run.rs
+++ b/tests/cli/action/proc_run.rs
@@ -327,7 +327,6 @@ fn should_support_json_to_forward_stdin_to_remote_process(ctx: &'_ DistantServer
     let mut child = distant_subcommand(ctx, "action")
         .args(&["--format", "json"])
         .arg("--interactive")
-        .args(&["--log-file", "/tmp/test.log", "-vvv"])
         .spawn()
         .unwrap();
 


### PR DESCRIPTION
* Add `SessionExt` trait for friendlier methods
* Create `Mailbox` and internal `PostOffice` to manage responses to requests
* Refactor `Session` to use a new `SessionChannel` underneath
* Refactor `Response` to always include an origin_id field instead of being optional
* Update `ProcStdout`, `ProcStderr`, and `ProcDone` to include origin id
* Replace `verbose` option with `log-level`