### PR TITLE
Refactor codebase to support Minimum Supported Rust Version (MSRV) of 1.51.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - { rust: stable, os: ubuntu-latest }
           - { rust: stable, os: macos-latest }
           - { rust: stable, os: windows-latest }
+          - { rust: 1.51.0, os: ubuntu-latest }
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.rust }}
@@ -44,6 +45,7 @@ jobs:
           - { rust: stable, os: ubuntu-latest }
           - { rust: stable, os: macos-latest }
           # - { rust: stable, os: windows-latest }
+          - { rust: 1.51.0, os: ubuntu-latest }
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.rust }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # distant
 
-[![Crates.io][distant_crates_img]][distant_crates_lnk] [![Docs.rs][distant_doc_img]][distant_doc_lnk] [![CI][distant_ci_img]][distant_ci_lnk]
+[![Crates.io][distant_crates_img]][distant_crates_lnk] [![Docs.rs][distant_doc_img]][distant_doc_lnk] [![CI][distant_rustc_img]][distant_rustc_lnk] [![CI][distant_ci_img]][distant_ci_lnk]
 
 [distant_crates_img]: https://img.shields.io/crates/v/distant.svg
 [distant_crates_lnk]: https://crates.io/crates/distant
@@ -8,6 +8,8 @@
 [distant_doc_lnk]: https://docs.rs/distant
 [distant_ci_img]: https://github.com/chipsenkbeil/distant/actions/workflows/ci.yml/badge.svg
 [distant_ci_lnk]: https://github.com/chipsenkbeil/distant/actions/workflows/ci.yml
+[distant_rustc_img]: https://img.shields.io/badge/distant-rustc_1.51+-lightgray.svg
+[distant_rustc_lnk]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html
 
 Binary to connect with a remote machine to edit files and run programs.
 

--- a/core/README.md
+++ b/core/README.md
@@ -6,7 +6,7 @@
 [distant_crates_lnk]: https://crates.io/crates/distant-core
 [distant_doc_img]: https://docs.rs/distant-core/badge.svg
 [distant_doc_lnk]: https://docs.rs/distant-core
-[distant_rustc_img]: https://img.shields.io/badge/distant-core-rustc_1.51+-lightgray.svg
+[distant_rustc_img]: https://img.shields.io/badge/distant_core-rustc_1.51+-lightgray.svg
 [distant_rustc_lnk]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html
 
 Library that powers the [`distant`](https://github.com/chipsenkbeil/distant)

--- a/core/README.md
+++ b/core/README.md
@@ -1,11 +1,13 @@
 # distant core
 
-[![Crates.io][distant_crates_img]][distant_crates_lnk] [![Docs.rs][distant_doc_img]][distant_doc_lnk] 
+[![Crates.io][distant_crates_img]][distant_crates_lnk] [![Docs.rs][distant_doc_img]][distant_doc_lnk] [![Rustc 1.51.0][distant_rustc_img]][distant_rustc_lnk]
 
 [distant_crates_img]: https://img.shields.io/crates/v/distant-core.svg
 [distant_crates_lnk]: https://crates.io/crates/distant-core
 [distant_doc_img]: https://docs.rs/distant-core/badge.svg
 [distant_doc_lnk]: https://docs.rs/distant-core
+[distant_rustc_img]: https://img.shields.io/badge/distant-core-rustc_1.51+-lightgray.svg
+[distant_rustc_lnk]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html
 
 Library that powers the [`distant`](https://github.com/chipsenkbeil/distant)
 binary.

--- a/core/src/client/lsp/data.rs
+++ b/core/src/client/lsp/data.rs
@@ -277,14 +277,19 @@ impl FromStr for LspHeader {
         let mut content_type = None;
 
         for line in lines {
-            if let Some((name, value)) = line.split_once(':') {
-                match name {
-                    "Content-Length" => content_length = Some(value.trim().parse()?),
-                    "Content-Type" => content_type = Some(value.trim().to_string()),
-                    _ => return Err(LspHeaderParseError::BadHeaderField),
+            match line.find(':') {
+                Some(idx) if idx + 1 < line.len() => {
+                    let name = &line[..idx];
+                    let value = &line[(idx + 1)..];
+                    match name {
+                        "Content-Length" => content_length = Some(value.trim().parse()?),
+                        "Content-Type" => content_type = Some(value.trim().to_string()),
+                        _ => return Err(LspHeaderParseError::BadHeaderField),
+                    }
                 }
-            } else {
-                return Err(LspHeaderParseError::BadHeaderField);
+                _ => {
+                    return Err(LspHeaderParseError::BadHeaderField);
+                }
             }
         }
 

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -589,12 +589,6 @@ pub enum ErrorKind {
     /// reached prematurely
     UnexpectedEof,
 
-    /// This operation is unsupported on this platform
-    Unsupported,
-
-    /// An operation could not be completed, because it failed to allocate enough memory.
-    OutOfMemory,
-
     /// When a loop is encountered when walking a directory
     Loop,
 
@@ -629,8 +623,6 @@ impl From<io::ErrorKind> for ErrorKind {
             io::ErrorKind::Interrupted => Self::Interrupted,
             io::ErrorKind::Other => Self::Other,
             io::ErrorKind::UnexpectedEof => Self::UnexpectedEof,
-            io::ErrorKind::Unsupported => Self::Unsupported,
-            io::ErrorKind::OutOfMemory => Self::OutOfMemory,
 
             // This exists because io::ErrorKind is non_exhaustive
             _ => Self::Unknown,

--- a/core/src/net/transport/mod.rs
+++ b/core/src/net/transport/mod.rs
@@ -199,7 +199,7 @@ mod tests {
         let bytes = serde_cbor::to_vec(&data).unwrap();
         let len = (bytes.len() as u64).to_be_bytes();
         let mut frame = Vec::new();
-        frame.extend(len);
+        frame.extend(len.iter().copied());
         frame.extend(bytes);
 
         transport.send(data).await.unwrap();
@@ -232,7 +232,7 @@ mod tests {
         let bytes = serde_cbor::to_vec(&data).unwrap();
         let len = (bytes.len() as u64).to_be_bytes();
         let mut frame = Vec::new();
-        frame.extend(len);
+        frame.extend(len.iter().copied());
         frame.extend(bytes);
 
         tx.send(frame).await.unwrap();
@@ -256,7 +256,7 @@ mod tests {
         let bytes = serde_cbor::to_vec(&data).unwrap();
         let len = (bytes.len() as u64).to_be_bytes();
         let mut frame = Vec::new();
-        frame.extend(len);
+        frame.extend(len.iter().copied());
         frame.extend(bytes);
 
         tx.send(frame).await.unwrap();
@@ -293,7 +293,7 @@ mod tests {
             let bytes = serde_cbor::to_vec(&data).unwrap();
             let len = (bytes.len() as u64).to_be_bytes();
             let mut frame = Vec::new();
-            frame.extend(len);
+            frame.extend(len.iter().copied());
             frame.extend(bytes);
 
             tx.send(frame).await.unwrap();
@@ -318,7 +318,7 @@ mod tests {
             let bytes = serde_cbor::to_vec(&data).unwrap();
             let len = (bytes.len() as u64).to_be_bytes();
             let mut frame = Vec::new();
-            frame.extend(len);
+            frame.extend(len.iter().copied());
             frame.extend(bytes);
 
             tx.send(frame).await.unwrap();
@@ -344,7 +344,7 @@ mod tests {
             let bytes = serde_cbor::to_vec(&data).unwrap();
             let len = (bytes.len() as u64).to_be_bytes();
             let mut frame = Vec::new();
-            frame.extend(len);
+            frame.extend(len.iter().copied());
             frame.extend(bytes);
 
             wh.send(data).await.unwrap();

--- a/core/src/server/port.rs
+++ b/core/src/server/port.rs
@@ -64,12 +64,12 @@ impl FromStr for PortRange {
 
     /// Parses PORT into single range or PORT1:PORTN into full range
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.split_once(':') {
-            Some((start, end)) => Ok(Self {
-                start: start.parse()?,
-                end: Some(end.parse()?),
+        match s.find(':') {
+            Some(idx) if idx + 1 < s.len() => Ok(Self {
+                start: s[..idx].parse()?,
+                end: Some(s[(idx + 1)..].parse()?),
             }),
-            None => Ok(Self {
+            _ => Ok(Self {
                 start: s.parse()?,
                 end: None,
             }),

--- a/tests/cli/action/remove.rs
+++ b/tests/cli/action/remove.rs
@@ -215,13 +215,16 @@ fn should_support_json_output_for_error(mut action_cmd: Command) {
     assert!(
         matches!(
             res.payload[0],
+            // NOTE: After some refactoring, unknown error type shows up in
+            //       our CI but not on my local machine. I can't pin it down.
+            //       The description matches what we'd expect regarding the
+            //       directory not being empty, so for now going to support
+            //       either of these error kinds.
             ResponseData::Error(Error {
-                // NOTE: After some refactoring, unknown error type shows up in
-                //       our CI but not on my local machine. I can't pin it down.
-                //       The description matches what we'd expect regarding the
-                //       directory not being empty, so for now going to support
-                //       either of these error kinds.
-                kind: ErrorKind::Other | ErrorKind::Unknown,
+                kind: ErrorKind::Other,
+                ..
+            }) | ResponseData::Error(Error {
+                kind: ErrorKind::Unknown,
                 ..
             })
         ),


### PR DESCRIPTION
Seeing what is leveraged in later Rust versions, there's nothing critical beyond 1.51.0, which introduced const generics that we use for our SecretKey. So this rolls back some of the Rust library additions we were using in order to support building distant-core (and cli) on Rust 1.51.0 as the MSRV.

Also addresses #54, where someone was building with an older version of Rust that failed. Is good to be clear on what the minimum supported version of Rust is.