### PR TITLE
Integrate ignore crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,54 +97,58 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check Cargo availability
         run: cargo --version
-      - name: Install OpenSSH on Windows
-        run: |
-          # From https://gist.github.com/inevity/a0d7b9f1c5ba5a813917b92736122797
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-          function Unzip
-          {
-              param([string]$zipfile, [string]$outpath)
-
-              [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
-          }
-
-          $url = 'https://github.com/PowerShell/Win32-OpenSSH/releases/latest/'
-          $request = [System.Net.WebRequest]::Create($url)
-          $request.AllowAutoRedirect=$false
-          $response=$request.GetResponse()
-          $file = $([String]$response.GetResponseHeader("Location")).Replace('tag','download') + '/OpenSSH-Win64.zip'
-
-          $client = new-object system.Net.Webclient;
-          $client.DownloadFile($file ,"c:\\OpenSSH-Win64.zip")
-
-          Unzip "c:\\OpenSSH-Win64.zip" "C:\Program Files\" 
-          mv "c:\\Program Files\OpenSSH-Win64" "C:\Program Files\OpenSSH\" 
-
-          powershell.exe -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"
-
-          New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22,49152-65535
-
-          net start sshd
-
-          Set-Service sshd -StartupType Automatic
-          Set-Service ssh-agent -StartupType Automatic
-
-          cd "C:\Program Files\OpenSSH\"
-          Powershell.exe -ExecutionPolicy Bypass -Command '. .\FixHostFilePermissions.ps1 -Confirm:$false'
-
-          $registryPath = "HKLM:\SOFTWARE\OpenSSH\"
-          $Name = "DefaultShell"
-          $value = "C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"
-
-          IF(!(Test-Path $registryPath))
-            {
-              New-Item -Path $registryPath -Force
-              New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType String -Force
-          } ELSE {
-              New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType String -Force
-          }
-        shell: pwsh
+      - uses: nick-fields/retry@v2
+        name: Install OpenSSH on Windows
         if: matrix.os == 'windows-latest'
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: pwsh
+          command: |
+            # From https://gist.github.com/inevity/a0d7b9f1c5ba5a813917b92736122797
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            function Unzip
+            {
+                param([string]$zipfile, [string]$outpath)
+
+                [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+            }
+
+            $url = 'https://github.com/PowerShell/Win32-OpenSSH/releases/latest/'
+            $request = [System.Net.WebRequest]::Create($url)
+            $request.AllowAutoRedirect=$false
+            $response=$request.GetResponse()
+            $file = $([String]$response.GetResponseHeader("Location")).Replace('tag','download') + '/OpenSSH-Win64.zip'
+
+            $client = new-object system.Net.Webclient;
+            $client.DownloadFile($file ,"c:\\OpenSSH-Win64.zip")
+
+            Unzip "c:\\OpenSSH-Win64.zip" "C:\Program Files\" 
+            mv "c:\\Program Files\OpenSSH-Win64" "C:\Program Files\OpenSSH\" 
+
+            powershell.exe -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"
+
+            New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22,49152-65535
+
+            net start sshd
+
+            Set-Service sshd -StartupType Automatic
+            Set-Service ssh-agent -StartupType Automatic
+
+            cd "C:\Program Files\OpenSSH\"
+            Powershell.exe -ExecutionPolicy Bypass -Command '. .\FixHostFilePermissions.ps1 -Confirm:$false'
+
+            $registryPath = "HKLM:\SOFTWARE\OpenSSH\"
+            $Name = "DefaultShell"
+            $value = "C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+
+            IF(!(Test-Path $registryPath))
+              {
+                New-Item -Path $registryPath -Force
+                New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType String -Force
+            } ELSE {
+                New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType String -Force
+            }
       - name: Run net tests (default features)
         run: cargo nextest run --profile ci --release -p distant-net
       - name: Build core (default features)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `min_depth` option from search
+- Updated search to properly use binary detection, filter out common ignore
+  file patterns, and execute in parallel via the `ignore` crate and `num_cpus`
+  crate to calculate thread count
+
 ## [0.19.0] - 2022-08-30
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "futures",
  "grep",
  "hex",
+ "ignore",
  "indoc",
  "log",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "indoc",
  "log",
  "notify",
+ "num_cpus",
  "once_cell",
  "portable-pty",
  "predicates",

--- a/distant-core/Cargo.toml
+++ b/distant-core/Cargo.toml
@@ -26,6 +26,7 @@ hex = "0.4.3"
 ignore = "0.4.18"
 log = "0.4.17"
 notify = { version = "=5.0.0-pre.15", features = ["serde"] }
+num_cpus = "1.13.1"
 once_cell = "1.13.0"
 portable-pty = "0.7.0"
 rand = { version = "0.8.5", features = ["getrandom"] }

--- a/distant-core/Cargo.toml
+++ b/distant-core/Cargo.toml
@@ -23,6 +23,7 @@ distant-net = { version = "=0.19.0", path = "../distant-net" }
 futures = "0.3.21"
 grep = "0.2.10"
 hex = "0.4.3"
+ignore = "0.4.18"
 log = "0.4.17"
 notify = { version = "=5.0.0-pre.15", features = ["serde"] }
 once_cell = "1.13.0"

--- a/distant-core/src/api/local/state/search.rs
+++ b/distant-core/src/api/local/state/search.rs
@@ -285,9 +285,11 @@ impl SearchQueryExecutor {
             walker_builder.add(path);
         }
 
+        // TODO: Use something like num_cpus to determine thread count
         walker_builder
             .skip_stdout(true)
             .follow_links(query.options.follow_symbolic_links)
+            .threads(8)
             .max_depth(
                 query
                     .options

--- a/distant-core/src/data/search.rs
+++ b/distant-core/src/data/search.rs
@@ -170,15 +170,6 @@ pub struct SearchQueryOptions {
     #[serde(default)]
     pub limit: Option<u64>,
 
-    /// Minimum depth (directories) to search
-    ///
-    /// The smallest depth is 0 and always corresponds to the path given to the new function on
-    /// this type. Its direct descendents have depth 1, and their descendents have depth 2, and so
-    /// on.
-    #[cfg_attr(feature = "clap", clap(long))]
-    #[serde(default)]
-    pub min_depth: Option<u64>,
-
     /// Maximum depth (directories) to search
     ///
     /// The smallest depth is 0 and always corresponds to the path given to the new function on

--- a/distant-net/src/server/ext.rs
+++ b/distant-net/src/server/ext.rs
@@ -121,7 +121,7 @@ where
                 match result {
                     Ok(x) => x,
                     Err(x) => {
-                        error!("Server no longer accepting connections: {}", x);
+                        error!("Server no longer accepting connections: {x}");
                         if let Some(timer) = shutdown_timer.take() {
                             timer.lock().await.abort();
                         }
@@ -160,9 +160,8 @@ where
         let (tx, mut rx) = mpsc::channel::<Response<Res>>(1);
         connection.writer_task = Some(tokio::spawn(async move {
             while let Some(data) = rx.recv().await {
-                // trace!("[Conn {}] Sending {:?}", connection_id, data.payload);
                 if let Err(x) = writer.write(data).await {
-                    error!("[Conn {}] Failed to send {:?}", connection_id, x);
+                    error!("[Conn {connection_id}] Failed to send {x}");
                     break;
                 }
             }
@@ -194,7 +193,7 @@ where
                         server.on_request(ctx).await;
                     }
                     Ok(None) => {
-                        debug!("[Conn {}] Connection closed", connection_id);
+                        debug!("[Conn {connection_id}] Connection closed");
 
                         // Remove the connection from our state if it has closed
                         if let Some(state) = Weak::upgrade(&weak_state) {
@@ -214,7 +213,7 @@ where
                         //       if someone sends bad data at any point, but does not
                         //       mean that the reader itself has failed. This can
                         //       happen from getting non-compliant typed data
-                        error!("[Conn {}] {}", connection_id, x);
+                        error!("[Conn {connection_id}] {x}");
                     }
                 }
             }


### PR DESCRIPTION
Integrates the [ignore](https://crates.io/crates/ignore) crate to support smarter ignoring of files, fixes searchers to use binary detection to avoid long and painful searches, and switches to parallel searching with smart thread count detection.