### PR TITLE
fix(parser): allow `-` (hyphen) to appear in usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `crossbeam-channel` dependency removed from notify by disabling its feature
   in order to avoid a `tokio::spawn` issue (https://github.com/notify-rs/notify/issues/380)
 
+### Fixed
+
+- usernames with `-` (hyphen) we're rejected as invalid
+
 ## [0.20.0-alpha.7]
 
 ### Added


### PR DESCRIPTION
Fixes #197

Usernames may contains hyphens now. Examples:

`some-user`, `-some-user`, `some-user-`

## Further solutions

Introduce [regex](https://docs.rs/regex/latest/regex/) to deal with parsing the input into a `Destination`. On one hand, it has the potential to make the code simpler. On the other hand, it's a dependency on the regex crate.