### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719254875,
+        "narHash": "sha256-ECni+IkwXjusHsm9Sexdtq8weAq/yUyt1TWIemXt3Ko=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2893f56de08021cffd9b6b6dfc70fd9ccd51eb60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Library and tooling that supports remote filesystem and process operations";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: {
+    packages = builtins.listToAttrs (map (systemName: {
+      name = systemName;
+      value = { default =
+        with import nixpkgs { system = systemName; };
+        pkgs.rustPlatform.buildRustPackage rec {
+          name = "distant";
+
+          # Update this whenever you release a new version. Make sure to omit the 'v'.
+          version = "0.20.0-unstable";
+          src = self;
+
+          # Update this whenever you update Cargo.lock
+          cargoHash = "sha256-mPcrfBFgvbPi6O7i9FCtN3iaaEOHIcDFHCOpV1NxKMY=";
+
+          # Build time
+          nativeBuildInputs = with pkgs; [ perl ];
+
+          meta = {
+            pname = "distant";
+            description = "Library and tooling that supports remote filesystem and process operations.";
+            longDescription = ''
+              Libraries and tooling for working remotely.
+              Deploy distant on your server and connect today to begin remote work!
+            '';
+            homepage = "https://distant.dev";
+            license = with lib.licenses; [ mit asl20 ];
+          };
+        };
+      };
+    })
+    [ "x86_64-linux" "armv7l-linux"
+      "aarch64-darwin" "x86_64-darwin" ]);
+  };
+}


### PR DESCRIPTION
Warning: The test `options::common::address::tests::resolve_should_properly_resolve_bind_address` fails on my system, which is x86_64-unknown-linux-gnu running NixOS.

I turned this into a flake by [request]( https://github.com/NixOS/nixpkgs/issues/322458 ) of @dgmcguire.