### PR TITLE
Fix Android release build by disabling default pty feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
             build: --all-features
             deps: musl-tools
           - target: aarch64-linux-android
-            build: --features docker,host,ssh
+            build: --no-default-features --features docker,host,ssh
     steps:
       - uses: actions/checkout@v4
       - name: Stamp nightly version


### PR DESCRIPTION
## Summary
- The Android (`aarch64-linux-android`) release target used `--features docker,host,ssh` without `--no-default-features`, so the default `pty` feature remained enabled
- This pulled in `portable-pty` which calls `openpty()`, a symbol unavailable on Android's Bionic libc, causing a linker error
- Added `--no-default-features` to the Android build flags to disable `pty`

## Test plan
- [ ] Re-trigger the nightly workflow and confirm the Android job passes