### PR TITLE
Fix Android release build by gating distant-host defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }
 [workspace.dependencies]
 distant-core = { version = "=0.21.0-dev", path = "distant-core" }
 distant-docker = { version = "=0.21.0-dev", path = "distant-docker" }
-distant-host = { version = "=0.21.0-dev", path = "distant-host" }
+distant-host = { version = "=0.21.0-dev", path = "distant-host", default-features = false }
 distant-ssh = { version = "=0.21.0-dev", path = "distant-ssh", default-features = false, features = ["serde"] }
 
 [profile.release]
@@ -44,7 +44,7 @@ panic = "abort"
 [features]
 default = ["docker", "host", "ssh", "pty"]
 docker = ["dep:distant-docker"]
-host = ["dep:distant-host"]
+host = ["dep:distant-host", "distant-host/macos-fsevent"]
 pty = ["distant-host/pty"]
 ssh = ["dep:distant-ssh"]
 


### PR DESCRIPTION
## Summary

- Disable `distant-host`'s default features at the workspace dependency level (adds `default-features = false`), preventing `portable-pty` from being unconditionally pulled in
- Explicitly re-enable `distant-host/macos-fsevent` in the root `host` feature, since we disabled defaults
- The `pty` feature remains correctly gated behind the root `pty` feature flag (line 48)

PR #270 added `--no-default-features` to the CI build command, but that only disables the **root crate's** defaults. `distant-host`'s own defaults (`pty` → `portable-pty`) were still pulled in, causing `undefined symbol: openpty` on Android's Bionic libc.

## Test plan

- [x] `cargo check --no-default-features --features host -p distant` — compiles without `portable-pty`
- [x] `cargo check --all-features --workspace` — compiles with pty included (no regression)
- [x] `cargo tree --no-default-features --features host -p distant -e normal -i portable-pty` — confirms `portable-pty` is absent from normal deps
- [ ] Nightly CI Android job passes