### PR TITLE
Fix CI flakiness in macOS watch test and Windows SSH tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,9 @@
 [test-groups.ssh-integration]
 max-threads = 4
 
+[test-groups.ssh-integration-windows]
+max-threads = 2
+
 [test-groups.docker-integration]
 max-threads = 2
 
@@ -9,6 +12,11 @@ fail-fast = false
 leak-timeout = { period = "100ms", result = "fail" }
 status-level = "fail"
 final-status-level = "leak"
+
+[[profile.default.overrides]]
+filter = 'binary_id(distant-ssh::lib)'
+platform = 'cfg(target_os = "windows")'
+test-group = 'ssh-integration-windows'
 
 [[profile.default.overrides]]
 filter = 'binary_id(distant-ssh::lib)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,25 @@ jobs:
           # Stop the system sshd service — it ships running on the windows-latest
           # VM image and interferes with per-test sshd instances (the user-context
           # sshd -z subprocess hangs, producing no output on exec/sftp channels).
-          Stop-Service sshd -ErrorAction SilentlyContinue
-          Set-Service sshd -StartupType Disabled
+          $sshService = Get-Service sshd -ErrorAction SilentlyContinue
+          if ($sshService -and $sshService.Status -eq 'Running') {
+            Stop-Service sshd -Force
+            $sshService.WaitForStatus('Stopped', '00:00:30')
+            Write-Host "System sshd service stopped successfully"
+          }
+          Set-Service sshd -StartupType Disabled -ErrorAction SilentlyContinue
+
+          # Kill any leftover sshd processes not managed by the service
+          Get-Process sshd -ErrorAction SilentlyContinue | Stop-Process -Force
+          Write-Host "Killed any leftover sshd processes"
+
+          # Verify nothing is listening on port 22
+          $listeners = netstat -an | Select-String ":22\s+.*LISTEN"
+          if ($listeners) {
+            Write-Error "Port 22 still in use after stopping sshd:`n$listeners"
+            exit 1
+          }
+          Write-Host "Verified: no process listening on port 22"
 
           # Ensure ssh-agent is available for key management
           Set-Service ssh-agent -StartupType Automatic

--- a/distant-host/src/api.rs
+++ b/distant-host/src/api.rs
@@ -1635,51 +1635,53 @@ mod tests {
         let nested_file = dir.child("nested-file");
         nested_file.write_str("some text").unwrap();
 
-        // Sleep a bit to give time to get all changes happening
-        // TODO: Can we slim down this sleep? Or redesign test in some other way?
-        tokio::time::sleep(DEBOUNCE_TIMEOUT + Duration::from_millis(100)).await;
+        // Collect responses until we see events for both paths (or timeout).
+        // A single file modification can produce multiple events (Attribute, Modify, etc.),
+        // so we track which paths have been seen rather than counting total responses.
+        let file_canonical = file.path().to_path_buf().canonicalize().unwrap();
+        let nested_canonical = nested_file.path().to_path_buf().canonicalize().unwrap();
 
-        // Collect all responses, as we may get multiple for interactions within a directory
         let mut responses = Vec::new();
-        while let Ok(res) = rx.try_recv() {
-            responses.push(res);
+        let mut seen_file = false;
+        let mut seen_nested = false;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while !seen_file || !seen_nested {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Some(res)) => {
+                    if !seen_file {
+                        seen_file = validate_changed_path(
+                            &res,
+                            &file_canonical,
+                            /* should_panic */ false,
+                        );
+                    }
+                    if !seen_nested {
+                        seen_nested = validate_changed_path(
+                            &res,
+                            &nested_canonical,
+                            /* should_panic */ false,
+                        );
+                    }
+                    responses.push(res);
+                }
+                Ok(None) => break, // channel closed
+                Err(_) => break,   // timeout
+            }
         }
 
-        // Validate that we have at least one change reported for each of our paths
-        assert!(
-            responses.len() >= 2,
-            "Less than expected total responses: {:?}",
-            responses
-        );
+        let response_strs: Vec<String> = responses.iter().map(|x| format!("{:?}", x)).collect();
 
-        let path = file.path().to_path_buf();
         assert!(
-            responses.iter().any(|res| validate_changed_path(
-                res,
-                &file.path().to_path_buf().canonicalize().unwrap(),
-                /* should_panic */ false,
-            )),
+            seen_file,
             "Missing {:?} in {:?}",
-            path,
-            responses
-                .iter()
-                .map(|x| format!("{:?}", x))
-                .collect::<Vec<String>>(),
+            file.path().to_path_buf(),
+            response_strs,
         );
-
-        let path = nested_file.path().to_path_buf();
         assert!(
-            responses.iter().any(|res| validate_changed_path(
-                res,
-                &file.path().to_path_buf().canonicalize().unwrap(),
-                /* should_panic */ false,
-            )),
+            seen_nested,
             "Missing {:?} in {:?}",
-            path,
-            responses
-                .iter()
-                .map(|x| format!("{:?}", x))
-                .collect::<Vec<String>>(),
+            nested_file.path().to_path_buf(),
+            response_strs,
         );
     }
 

--- a/distant-ssh/tests/sshd/mod.rs
+++ b/distant-ssh/tests/sshd/mod.rs
@@ -898,19 +898,27 @@ pub async fn load_ssh_client(sshd: &Sshd) -> Ssh {
     for attempt in 1..=max_attempts {
         for addr in &addrs {
             let addr_string = addr.to_string();
-            match Ssh::connect(&addr_string, opts.clone()).await {
-                Ok(mut ssh_client) => match ssh_client.authenticate(MockSshAuthHandler).await {
-                    Ok(_) => return ssh_client,
-                    Err(x) => {
-                        errors.push(anyhow::Error::new(x).context(format!(
-                            "Failed to authenticate with sshd @ {addr_string} (attempt {attempt})"
-                        )));
-                    }
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                async {
+                    let mut ssh_client = Ssh::connect(&addr_string, opts.clone()).await?;
+                    ssh_client.authenticate(MockSshAuthHandler).await?;
+                    Ok::<_, std::io::Error>(ssh_client)
                 },
-                Err(x) => {
+            )
+            .await;
+
+            match result {
+                Ok(Ok(ssh_client)) => return ssh_client,
+                Ok(Err(x)) => {
                     errors.push(anyhow::Error::new(x).context(format!(
-                        "Failed to connect to sshd @ {addr_string} (attempt {attempt})"
+                        "Failed to connect/auth @ {addr_string} (attempt {attempt})"
                     )));
+                }
+                Err(_) => {
+                    errors.push(anyhow::anyhow!(
+                        "Timed out connecting to sshd @ {addr_string} after 10s (attempt {attempt})"
+                    ));
                 }
             }
         }

--- a/distant-test-harness/src/sshd.rs
+++ b/distant-test-harness/src/sshd.rs
@@ -839,19 +839,24 @@ pub async fn load_ssh_client(sshd: &Sshd) -> Ssh {
     for attempt in 1..=max_attempts {
         for addr in &addrs {
             let addr_string = addr.to_string();
-            match Ssh::connect(&addr_string, opts.clone()).await {
-                Ok(mut ssh_client) => match ssh_client.authenticate(MockSshAuthHandler).await {
-                    Ok(_) => return ssh_client,
-                    Err(x) => {
-                        errors.push(anyhow::Error::new(x).context(format!(
-                            "Failed to authenticate with sshd @ {addr_string} (attempt {attempt})"
-                        )));
-                    }
-                },
-                Err(x) => {
+            let result = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                let mut ssh_client = Ssh::connect(&addr_string, opts.clone()).await?;
+                ssh_client.authenticate(MockSshAuthHandler).await?;
+                Ok::<_, std::io::Error>(ssh_client)
+            })
+            .await;
+
+            match result {
+                Ok(Ok(ssh_client)) => return ssh_client,
+                Ok(Err(x)) => {
                     errors.push(anyhow::Error::new(x).context(format!(
-                        "Failed to connect to sshd @ {addr_string} (attempt {attempt})"
+                        "Failed to connect/auth @ {addr_string} (attempt {attempt})"
                     )));
+                }
+                Err(_) => {
+                    errors.push(anyhow::anyhow!(
+                        "Timed out connecting to sshd @ {addr_string} after 10s (attempt {attempt})"
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Fix copy-paste bug** in `watch_should_support_watching_a_directory_recursively` — the second assertion validated `file.path()` instead of `nested_file.path()`, so the nested file watcher event was never checked
- **Replace sleep + try_recv with deadline-bounded recv loop** that tracks distinct paths seen, preventing false passes when a single file emits multiple events (Attribute + Modify) before the nested file event arrives
- **Add 10s timeout** around `Ssh::connect()` + `authenticate()` in both test harnesses (`distant-test-harness/src/sshd.rs` and `distant-ssh/tests/sshd/mod.rs`) so hung connections fail fast and retry instead of blocking for 90s until nextest kills the test
- **Harden CI sshd shutdown** in `.github/workflows/ci.yml` — verify the service actually stopped, kill leftover sshd processes, and assert port 22 is free before running tests
- **Add `ssh-integration-windows` nextest group** with `max-threads = 2` to reduce SSH test parallelism on Windows (vs 4 on other platforms)

## Test plan

- [x] `cargo test --all-features -p distant-host watch_should_support_watching_a_directory_recursively` passes locally
- [x] `cargo test --all-features -p distant-ssh --no-run` compiles successfully
- [x] `cargo clippy --all-features --workspace --all-targets` passes with no warnings
- [ ] Verify macOS CI no longer fails the watch test
- [ ] Verify Windows CI SSH tests pass (or fail fast with timeout errors instead of hanging)