### PR TITLE
Fix SSH data loss after ExitStatus and Windows stderr test flakiness

### DIFF
--- a/distant-ssh/src/process.rs
+++ b/distant-ssh/src/process.rs
@@ -10,6 +10,12 @@ use tokio::sync::mpsc;
 
 use crate::ClientHandler;
 
+/// Time to wait after receiving ExitStatus to drain any remaining
+/// Data/ExtendedData messages. SSH RFC 4254 provides no ordering
+/// guarantee between data and exit-status, so on Windows especially,
+/// stderr (ExtendedData) may arrive after ExitStatus.
+const POST_EXIT_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Represents a spawned process
 pub struct Process {
     pub id: ProcessId,
@@ -118,9 +124,31 @@ where
                 } => {
                     log::debug!("spawn_simple reader: ExitStatus({status}) for pid={msg_id}");
                     exit_status = Some(status);
-                    // On Windows, sshd may not send Eof after ExitStatus.
-                    // Break immediately — ExitStatus arrives after all data
-                    // has been flushed, so no output will be lost.
+                    // Don't break immediately — on Windows, ExtendedData (stderr)
+                    // may arrive after ExitStatus. Drain remaining messages with
+                    // a short timeout per SSH RFC 4254 (no ordering guarantee).
+                    let drain_deadline = tokio::time::Instant::now() + POST_EXIT_DRAIN_TIMEOUT;
+                    loop {
+                        match tokio::time::timeout_at(drain_deadline, read_half.wait()).await {
+                            Ok(Some(ChannelMsg::Data { ref data })) => {
+                                let _ = stdout_reply.send(Response::ProcStdout {
+                                    id: msg_id,
+                                    data: data.to_vec(),
+                                });
+                            }
+                            Ok(Some(ChannelMsg::ExtendedData { ref data, ext: 1 })) => {
+                                let _ = stderr_reply.send(Response::ProcStderr {
+                                    id: msg_id,
+                                    data: data.to_vec(),
+                                });
+                            }
+                            Ok(Some(ChannelMsg::Eof))
+                            | Ok(Some(ChannelMsg::Close))
+                            | Ok(None)
+                            | Err(_) => break,
+                            Ok(Some(_)) => {} // ignore other messages during drain
+                        }
+                    }
                     break;
                 }
                 ChannelMsg::ExitSignal { signal_name, .. } => {
@@ -292,9 +320,25 @@ where
                 } => {
                     log::debug!("spawn_pty reader: ExitStatus({status}) for pid={msg_id}");
                     exit_status = Some(status);
-                    // On Windows, sshd may not send Eof after ExitStatus.
-                    // Break immediately — ExitStatus arrives after all data
-                    // has been flushed, so no output will be lost.
+                    // Don't break immediately — on Windows, Data may arrive
+                    // after ExitStatus. Drain remaining messages with a short
+                    // timeout per SSH RFC 4254 (no ordering guarantee).
+                    let drain_deadline = tokio::time::Instant::now() + POST_EXIT_DRAIN_TIMEOUT;
+                    loop {
+                        match tokio::time::timeout_at(drain_deadline, read_half.wait()).await {
+                            Ok(Some(ChannelMsg::Data { ref data })) => {
+                                let _ = stdout_reply.send(Response::ProcStdout {
+                                    id: msg_id,
+                                    data: data.to_vec(),
+                                });
+                            }
+                            Ok(Some(ChannelMsg::Eof))
+                            | Ok(Some(ChannelMsg::Close))
+                            | Ok(None)
+                            | Err(_) => break,
+                            Ok(Some(_)) => {} // ignore other messages during drain
+                        }
+                    }
                     break;
                 }
                 ChannelMsg::ExitSignal { signal_name, .. } => {

--- a/distant-ssh/src/utils.rs
+++ b/distant-ssh/src/utils.rs
@@ -92,9 +92,35 @@ pub async fn execute_output(
                 } => {
                     log::debug!("execute_output: received ExitStatus({status}) for cmd={cmd}");
                     exit_status = Some(status);
-                    // On Windows, sshd may not send Eof after ExitStatus.
-                    // Break immediately — ExitStatus is sent after all data
-                    // has been flushed, so no output will be lost.
+                    // Don't break immediately — on Windows, ExtendedData
+                    // (stderr) may arrive after ExitStatus. Drain remaining
+                    // messages with a short timeout per SSH RFC 4254 (no
+                    // ordering guarantee).
+                    let drain_deadline =
+                        tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+                    loop {
+                        match tokio::time::timeout_at(drain_deadline, channel.wait()).await {
+                            Ok(Some(ChannelMsg::Data { ref data })) => {
+                                log::debug!(
+                                    "execute_output: drain Data ({} bytes) for cmd={cmd}",
+                                    data.len()
+                                );
+                                stdout.extend_from_slice(data);
+                            }
+                            Ok(Some(ChannelMsg::ExtendedData { ref data, ext: 1 })) => {
+                                log::debug!(
+                                    "execute_output: drain ExtendedData ({} bytes) for cmd={cmd}",
+                                    data.len()
+                                );
+                                stderr.extend_from_slice(data);
+                            }
+                            Ok(Some(ChannelMsg::Eof))
+                            | Ok(Some(ChannelMsg::Close))
+                            | Ok(None)
+                            | Err(_) => break,
+                            Ok(Some(_)) => {}
+                        }
+                    }
                     break;
                 }
                 ChannelMsg::Eof => {

--- a/distant-ssh/tests/ssh/client.rs
+++ b/distant-ssh/tests/ssh/client.rs
@@ -1667,7 +1667,12 @@ async fn proc_spawn_should_send_back_stdout_periodically_when_available(
 ) {
     let mut client = client.await;
 
-    let cmd = platform_cmd("sh -c 'printf \"%s\" \"some stdout\"'", "echo some stdout");
+    // On Windows, `ping -n 2 127.0.0.1 >nul` keeps the process alive ~1s after
+    // writing stdout, giving sshd time to flush the pipe before exit.
+    let cmd = platform_cmd(
+        "sh -c 'printf \"%s\" \"some stdout\"'",
+        "cmd /c \"echo some stdout & ping -n 2 127.0.0.1 >nul\"",
+    );
     let mut proc = client
         .spawn(
             cmd,
@@ -1680,7 +1685,7 @@ async fn proc_spawn_should_send_back_stdout_periodically_when_available(
 
     let stdout_pipe = proc.stdout.as_mut().unwrap();
     let mut accumulated = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     loop {
         match tokio::time::timeout_at(deadline, stdout_pipe.read()).await {
             Ok(Ok(data)) => {
@@ -1713,9 +1718,11 @@ async fn proc_spawn_should_send_back_stderr_periodically_when_available(
 ) {
     let mut client = client.await;
 
+    // On Windows, `ping -n 2 127.0.0.1 >nul` keeps the process alive ~1s after
+    // writing stderr, giving sshd time to flush the pipe before exit.
     let cmd = platform_cmd(
         "sh -c 'printf \"%s\" \"some stderr\" >&2'",
-        "echo some stderr 1>&2",
+        "cmd /c \"echo some stderr 1>&2 & ping -n 2 127.0.0.1 >nul\"",
     );
     let mut proc = client
         .spawn(
@@ -1729,7 +1736,7 @@ async fn proc_spawn_should_send_back_stderr_periodically_when_available(
 
     let stderr_pipe = proc.stderr.as_mut().unwrap();
     let mut accumulated = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     loop {
         match tokio::time::timeout_at(deadline, stderr_pipe.read()).await {
             Ok(Ok(data)) => {


### PR DESCRIPTION
## Summary

- **Production fix**: After receiving `ExitStatus` in `spawn_simple`, `spawn_pty`, and `execute_output`, drain remaining `Data`/`ExtendedData` messages with a 500ms timeout instead of breaking immediately. SSH RFC 4254 provides no ordering guarantee between data and exit-status — on Windows, sshd may deliver stderr after ExitStatus. The drain exits early on `Eof`/`Close`, so on Unix there is no added latency.
- **Test fix**: Windows test commands now use `cmd /c "echo ... & ping -n 2 127.0.0.1 >nul"` to keep the process alive ~1s after writing output, giving sshd time to flush the pipe before exit. Test deadlines increased from 5s to 15s.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-features -p distant-ssh --all-targets` (with `-Dwarnings`) — clean
- [x] `cargo test --all-features -p distant-ssh proc_spawn_should_send_back_stderr_periodically` — passes
- [x] `cargo test --all-features -p distant-ssh proc_spawn_should_send_back_stdout_periodically` — passes
- [x] `cargo test --all-features -p distant-ssh --lib` — all 259 unit tests pass
- [ ] Verify Windows CI passes (the primary target of this fix)