### PR TITLE
Fix nightly release 403 by replacing action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,33 +17,6 @@ on:
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
-
-# Status of Targets:
-#
-# ✅ x86_64-apple-darwin
-# ✅ aarch64-apple-darwin
-#
-# ✅ x86_64-pc-windows-msvc
-# ✅ aarch64-pc-windows-msvc
-#
-# ✅ x86_64-unknown-linux-gnu
-# ✅ aarch64-unknown-linux-gnu
-# ✅ aarch64-linux-android (runner NDK)
-# ✅ armv7-unknown-linux-gnueabihf
-#
-# ✅ x86_64-unknown-linux-musl
-# ✅ aarch64-unknown-linux-musl
-#
-# ✅ x86_64-unknown-freebsd (VM via cross-platform-actions)
-# ✅ aarch64-unknown-freebsd (VM via cross-platform-actions)
-#
-# ✅ x86_64-unknown-netbsd (VM via cross-platform-actions)
-# ✅ aarch64-unknown-netbsd (VM via cross-platform-actions)
-#
-# ❓ x86_64-unknown-openbsd (VM via cross-platform-actions; validate rustc ICE is fixed)
-# ✅ aarch64-unknown-openbsd (VM via cross-platform-actions; openssl removed by russh migration)
-#
-
 jobs:
   validate:
     name: "Pre-release validation"


### PR DESCRIPTION
## Summary

- Replace `softprops/action-gh-release@v2` with direct `gh release create` commands in both the nightly and tagged release publish steps
- The action has [4 open unresolved 403 issues](https://github.com/softprops/action-gh-release/issues/639) including a token-handling bug in its Octokit code that causes `Resource not accessible by integration` errors
- Add a "Collect release assets" step that enumerates all binaries, per-file checksums, and consolidated checksum files upfront, replacing glob-based file matching with explicit asset lists
- Both publish steps now use `--generate-notes` to append GitHub's auto-generated PR/commit list alongside the release notes

## Test plan

- [ ] Trigger the nightly path against this branch: `gh workflow run release.yml --ref feature/fix-nightly-publish --field nightly=true`
- [ ] Confirm the nightly release is created with all expected assets (binaries + checksums + SHA256SUMS + B2SUMS)
- [ ] Tagged release path uses the same `gh release create` mechanism — if nightly works, tagged will too
- [ ] If `gh` CLI also gets 403 (indicating a token-level issue rather than action bug), create a fine-grained PAT as fallback