### PR TITLE
Fix nightly release 403 and multiline asset expansion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: read
     env:
       GIT_REF: ${{ github.ref }}
       IS_NIGHTLY: ${{ inputs.nightly }}
@@ -384,18 +385,18 @@ jobs:
             exit 1
           fi
 
-          # Append the consolidated checksum files (these are named SHA256SUMS/B2SUMS,
-          # not distant-*, so find doesn't match them)
-          ASSET_FILES="$(echo "$ASSET_FILES")
-          SHA256SUMS
-          B2SUMS"
-
-          # Export as multiline output for use in later steps
-          {
-            echo "files<<EOF"
-            echo "$ASSET_FILES"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Build a single-line, space-separated list of all asset files
+          # (unquoted expansion + SC2086 disable lets bash word-split correctly)
+          ASSET_LINE=$(echo "$ASSET_FILES" | tr '\n' ' ')
+          echo "files=${ASSET_LINE}SHA256SUMS B2SUMS" >> "$GITHUB_OUTPUT"
+      - name: Debug token permissions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "=== gh auth status ==="
+          gh auth status
+          echo "=== test releases API ==="
+          gh api repos/${{ github.repository }}/releases --jq '.[0].tag_name' || echo "API call failed with exit $?"
       - name: Get Changelog Entry
         id: changelog
         uses: mindsers/changelog-reader-action@v2


### PR DESCRIPTION
## Summary

- **Fix multiline asset expansion**: The "Collect release assets" step used a heredoc multiline output. When substituted into `gh release create`, only the first file was passed as an arg — the rest became separate (failing) bash commands. Replaced with single-line space-separated format so bash word-splitting works correctly.
- **Add `pull-requests: read` permission**: May be required server-side by `--generate-notes` to list merged PRs.
- **Add temporary debug step**: Prints `gh auth status` and tests the releases API before publish, so if the 403 persists we have diagnostic data.

## Test plan

- [ ] Manually trigger release workflow with `nightly=true` from this branch
- [ ] Verify "Debug token permissions" step shows correct auth and API access
- [ ] Verify publish step succeeds (no 403, all assets uploaded)
- [ ] Remove debug step in a follow-up commit once 403 is confirmed resolved