### PR TITLE
Fix nightly release 403: add workflow-level permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: write
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -320,9 +323,6 @@ jobs:
       needs.linux.result == 'success' &&
       needs.bsd.result == 'success'
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      pull-requests: read
     env:
       GIT_REF: ${{ github.ref }}
       IS_NIGHTLY: ${{ inputs.nightly }}


### PR DESCRIPTION
## Summary

- The nightly release `publish` job fails with HTTP 403 when creating a GitHub release because `GITHUB_TOKEN` lacks write access
- **Root cause:** Job-level `permissions: contents: write` cannot escalate beyond the repository's default token scope when triggered via `workflow_dispatch` from `nightly.yml`
- **Fix:** Move `permissions: contents: write` to workflow level so the token inherits write access regardless of repo defaults; remove the now-redundant job-level block

## Test plan

- [ ] After merge, trigger nightly release: `gh workflow run release.yml --field nightly=true`
- [ ] Verify the `publish` job's `gh release create nightly` step succeeds (no 403)
- [ ] Verify tagged releases still work on next version tag push