### PR TITLE
Phase 1: Protocol consolidation (FileRead/FileWrite options + wire error visibility)

### DIFF
--- a/distant-core/src/api.rs
+++ b/distant-core/src/api.rs
@@ -8,8 +8,8 @@ use log::*;
 
 use crate::protocol::{
     self, ChangeKind, DirEntry, Environment, Error, Metadata, Permissions, ProcessId, PtySize,
-    RemotePath, SearchId, SearchQuery, SetPermissionsOptions, StatusInfo, SystemInfo, TunnelId,
-    Version,
+    ReadFileOptions, RemotePath, SearchId, SearchQuery, SetPermissionsOptions, StatusInfo,
+    SystemInfo, TunnelId, Version, WriteFileOptions,
 };
 
 mod reply;
@@ -72,6 +72,7 @@ pub trait Api {
     /// Reads bytes from a file.
     ///
     /// * `path` - the path to the file
+    /// * `options` - controls offset and length for range reads
     ///
     /// *Override this, otherwise it will return "unsupported" as an error.*
     #[allow(unused_variables)]
@@ -79,28 +80,16 @@ pub trait Api {
         &self,
         ctx: Ctx,
         path: RemotePath,
+        options: ReadFileOptions,
     ) -> impl Future<Output = io::Result<Vec<u8>>> + Send {
         async { unsupported("read_file") }
     }
 
-    /// Reads bytes from a file as text.
-    ///
-    /// * `path` - the path to the file
-    ///
-    /// *Override this, otherwise it will return "unsupported" as an error.*
-    #[allow(unused_variables)]
-    fn read_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-    ) -> impl Future<Output = io::Result<String>> + Send {
-        async { unsupported("read_file_text") }
-    }
-
-    /// Writes bytes to a file, overwriting the file if it exists.
+    /// Writes bytes to a file, creating it if it does not exist.
     ///
     /// * `path` - the path to the file
     /// * `data` - the data to write
+    /// * `options` - controls offset writes and append mode
     ///
     /// *Override this, otherwise it will return "unsupported" as an error.*
     #[allow(unused_variables)]
@@ -109,56 +98,9 @@ pub trait Api {
         ctx: Ctx,
         path: RemotePath,
         data: Vec<u8>,
+        options: WriteFileOptions,
     ) -> impl Future<Output = io::Result<()>> + Send {
         async { unsupported("write_file") }
-    }
-
-    /// Writes text to a file, overwriting the file if it exists.
-    ///
-    /// * `path` - the path to the file
-    /// * `data` - the data to write
-    ///
-    /// *Override this, otherwise it will return "unsupported" as an error.*
-    #[allow(unused_variables)]
-    fn write_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: String,
-    ) -> impl Future<Output = io::Result<()>> + Send {
-        async { unsupported("write_file_text") }
-    }
-
-    /// Writes bytes to the end of a file, creating it if it is missing.
-    ///
-    /// * `path` - the path to the file
-    /// * `data` - the data to append
-    ///
-    /// *Override this, otherwise it will return "unsupported" as an error.*
-    #[allow(unused_variables)]
-    fn append_file(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: Vec<u8>,
-    ) -> impl Future<Output = io::Result<()>> + Send {
-        async { unsupported("append_file") }
-    }
-
-    /// Writes bytes to the end of a file, creating it if it is missing.
-    ///
-    /// * `path` - the path to the file
-    /// * `data` - the data to append
-    ///
-    /// *Override this, otherwise it will return "unsupported" as an error.*
-    #[allow(unused_variables)]
-    fn append_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: String,
-    ) -> impl Future<Output = io::Result<()>> + Send {
-        async { unsupported("append_file_text") }
     }
 
     /// Reads entries from a directory.
@@ -632,33 +574,17 @@ where
             .await
             .map(protocol::Response::Version)
             .unwrap_or_else(protocol::Response::from),
-        protocol::Request::FileRead { path } => api
-            .read_file(ctx, path)
+        protocol::Request::FileRead { path, options } => api
+            .read_file(ctx, path, options)
             .await
             .map(|data| protocol::Response::Blob { data })
             .unwrap_or_else(protocol::Response::from),
-        protocol::Request::FileReadText { path } => api
-            .read_file_text(ctx, path)
-            .await
-            .map(|data| protocol::Response::Text { data })
-            .unwrap_or_else(protocol::Response::from),
-        protocol::Request::FileWrite { path, data } => api
-            .write_file(ctx, path, data)
-            .await
-            .map(|_| protocol::Response::Ok)
-            .unwrap_or_else(protocol::Response::from),
-        protocol::Request::FileWriteText { path, text } => api
-            .write_file_text(ctx, path, text)
-            .await
-            .map(|_| protocol::Response::Ok)
-            .unwrap_or_else(protocol::Response::from),
-        protocol::Request::FileAppend { path, data } => api
-            .append_file(ctx, path, data)
-            .await
-            .map(|_| protocol::Response::Ok)
-            .unwrap_or_else(protocol::Response::from),
-        protocol::Request::FileAppendText { path, text } => api
-            .append_file_text(ctx, path, text)
+        protocol::Request::FileWrite {
+            path,
+            data,
+            options,
+        } => api
+            .write_file(ctx, path, data, options)
             .await
             .map(|_| protocol::Response::Ok)
             .unwrap_or_else(protocol::Response::from),
@@ -864,18 +790,7 @@ mod tests {
         let api = DefaultApi;
         let (ctx, _rx) = make_ctx();
         let err = api
-            .read_file(ctx, RemotePath::from("/tmp"))
-            .await
-            .unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn default_read_file_text_returns_unsupported() {
-        let api = DefaultApi;
-        let (ctx, _rx) = make_ctx();
-        let err = api
-            .read_file_text(ctx, RemotePath::from("/tmp"))
+            .read_file(ctx, RemotePath::from("/tmp"), Default::default())
             .await
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -886,40 +801,7 @@ mod tests {
         let api = DefaultApi;
         let (ctx, _rx) = make_ctx();
         let err = api
-            .write_file(ctx, RemotePath::from("/tmp"), vec![1])
-            .await
-            .unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn default_write_file_text_returns_unsupported() {
-        let api = DefaultApi;
-        let (ctx, _rx) = make_ctx();
-        let err = api
-            .write_file_text(ctx, RemotePath::from("/tmp"), String::new())
-            .await
-            .unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn default_append_file_returns_unsupported() {
-        let api = DefaultApi;
-        let (ctx, _rx) = make_ctx();
-        let err = api
-            .append_file(ctx, RemotePath::from("/tmp"), vec![1])
-            .await
-            .unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn default_append_file_text_returns_unsupported() {
-        let api = DefaultApi;
-        let (ctx, _rx) = make_ctx();
-        let err = api
-            .append_file_text(ctx, RemotePath::from("/tmp"), String::new())
+            .write_file(ctx, RemotePath::from("/tmp"), vec![1], Default::default())
             .await
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -1194,7 +1076,12 @@ mod tests {
             })
         }
 
-        async fn read_file(&self, _ctx: Ctx, _path: RemotePath) -> io::Result<Vec<u8>> {
+        async fn read_file(
+            &self,
+            _ctx: Ctx,
+            _path: RemotePath,
+            _options: ReadFileOptions,
+        ) -> io::Result<Vec<u8>> {
             Ok(vec![1, 2, 3])
         }
 
@@ -1268,6 +1155,7 @@ mod tests {
         let (ctx, mut rx) = make_request_ctx(
             Msg::Single(protocol::Request::FileRead {
                 path: RemotePath::from("/test"),
+                options: Default::default(),
             }),
             Header::new(),
         );
@@ -1305,8 +1193,9 @@ mod tests {
     async fn on_request_single_unsupported_method_returns_error() {
         let handler = ApiServerHandler::new(MockApi);
         let (ctx, mut rx) = make_request_ctx(
-            Msg::Single(protocol::Request::FileReadText {
+            Msg::Single(protocol::Request::DirCreate {
                 path: RemotePath::from("/test"),
+                all: false,
             }),
             Header::new(),
         );
@@ -1345,17 +1234,18 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn on_request_batch_parallel_some_fail_all_run() {
         let handler = ApiServerHandler::new(MockApi);
-        // FileReadText is unsupported in our MockApi, but Version is supported.
+        // DirCreate is unsupported in our MockApi, but Version is supported.
         // In parallel mode, all should run regardless of failures.
         let (ctx, mut rx) = make_request_ctx(
             Msg::Batch(vec![
-                protocol::Request::FileReadText {
+                protocol::Request::DirCreate {
                     path: RemotePath::from("/missing"),
+                    all: false,
                 },
                 protocol::Request::Version {},
-                protocol::Request::FileWriteText {
+                protocol::Request::Remove {
                     path: RemotePath::from("/x"),
-                    text: String::from("data"),
+                    force: false,
                 },
             ]),
             Header::new(),
@@ -1416,8 +1306,9 @@ mod tests {
         let (ctx, mut rx) = make_request_ctx(
             Msg::Batch(vec![
                 protocol::Request::Version {},
-                protocol::Request::FileReadText {
+                protocol::Request::DirCreate {
                     path: RemotePath::from("/missing"),
+                    all: false,
                 },
                 protocol::Request::SystemInfo {},
             ]),
@@ -1450,8 +1341,9 @@ mod tests {
         header.insert("sequence", true);
         let (ctx, mut rx) = make_request_ctx(
             Msg::Batch(vec![
-                protocol::Request::FileReadText {
+                protocol::Request::DirCreate {
                     path: RemotePath::from("/missing"),
+                    all: false,
                 },
                 protocol::Request::Version {},
                 protocol::Request::SystemInfo {},

--- a/distant-core/src/client/ext.rs
+++ b/distant-core/src/client/ext.rs
@@ -11,8 +11,8 @@ use crate::client::{
 };
 use crate::protocol::{
     self, ChangeKindSet, DirEntry, Environment, Error as Failure, Metadata, Permissions, PtySize,
-    RemotePath, SearchId, SearchQuery, SetPermissionsOptions, StatusInfo, SystemInfo, TunnelId,
-    Version,
+    ReadFileOptions, RemotePath, SearchId, SearchQuery, SetPermissionsOptions, StatusInfo,
+    SystemInfo, TunnelId, Version, WriteFileOptions,
 };
 
 pub type AsyncReturn<'a, T, E = io::Error> =
@@ -87,7 +87,11 @@ pub trait ChannelExt {
     ) -> AsyncReturn<'_, (Vec<DirEntry>, Vec<Failure>)>;
 
     /// Reads a remote file as a collection of bytes
-    fn read_file(&mut self, path: impl Into<RemotePath>) -> AsyncReturn<'_, Vec<u8>>;
+    fn read_file(
+        &mut self,
+        path: impl Into<RemotePath>,
+        options: ReadFileOptions,
+    ) -> AsyncReturn<'_, Vec<u8>>;
 
     /// Returns a remote file as a string
     fn read_file_text(&mut self, path: impl Into<RemotePath>) -> AsyncReturn<'_, String>;
@@ -156,6 +160,7 @@ pub trait ChannelExt {
         &mut self,
         path: impl Into<RemotePath>,
         data: impl Into<Vec<u8>>,
+        options: WriteFileOptions,
     ) -> AsyncReturn<'_, ()>;
 
     /// Writes a remote file with the data from a string
@@ -216,7 +221,11 @@ impl ChannelExt for Channel<protocol::Msg<protocol::Request>, protocol::Msg<prot
     ) -> AsyncReturn<'_, ()> {
         make_body!(
             self,
-            protocol::Request::FileAppend { path: path.into(), data: data.into() },
+            protocol::Request::FileWrite {
+                path: path.into(),
+                data: data.into(),
+                options: WriteFileOptions { append: true, ..Default::default() },
+            },
             @ok
         )
     }
@@ -228,7 +237,11 @@ impl ChannelExt for Channel<protocol::Msg<protocol::Request>, protocol::Msg<prot
     ) -> AsyncReturn<'_, ()> {
         make_body!(
             self,
-            protocol::Request::FileAppendText { path: path.into(), text: data.into() },
+            protocol::Request::FileWrite {
+                path: path.into(),
+                data: data.into().into_bytes(),
+                options: WriteFileOptions { append: true, ..Default::default() },
+            },
             @ok
         )
     }
@@ -350,10 +363,17 @@ impl ChannelExt for Channel<protocol::Msg<protocol::Request>, protocol::Msg<prot
         )
     }
 
-    fn read_file(&mut self, path: impl Into<RemotePath>) -> AsyncReturn<'_, Vec<u8>> {
+    fn read_file(
+        &mut self,
+        path: impl Into<RemotePath>,
+        options: ReadFileOptions,
+    ) -> AsyncReturn<'_, Vec<u8>> {
         make_body!(
             self,
-            protocol::Request::FileRead { path: path.into() },
+            protocol::Request::FileRead {
+                path: path.into(),
+                options
+            },
             |data| match data {
                 protocol::Response::Blob { data } => Ok(data),
                 protocol::Response::Error(x) => Err(io::Error::from(x)),
@@ -363,15 +383,11 @@ impl ChannelExt for Channel<protocol::Msg<protocol::Request>, protocol::Msg<prot
     }
 
     fn read_file_text(&mut self, path: impl Into<RemotePath>) -> AsyncReturn<'_, String> {
-        make_body!(
-            self,
-            protocol::Request::FileReadText { path: path.into() },
-            |data| match data {
-                protocol::Response::Text { data } => Ok(data),
-                protocol::Response::Error(x) => Err(io::Error::from(x)),
-                _ => Err(mismatched_response()),
-            }
-        )
+        let path = path.into();
+        Box::pin(async move {
+            let data = self.read_file(path, Default::default()).await?;
+            Ok(String::from_utf8_lossy(&data).into_owned())
+        })
     }
 
     fn remove(&mut self, path: impl Into<RemotePath>, force: bool) -> AsyncReturn<'_, ()> {
@@ -507,10 +523,15 @@ impl ChannelExt for Channel<protocol::Msg<protocol::Request>, protocol::Msg<prot
         &mut self,
         path: impl Into<RemotePath>,
         data: impl Into<Vec<u8>>,
+        options: WriteFileOptions,
     ) -> AsyncReturn<'_, ()> {
         make_body!(
             self,
-            protocol::Request::FileWrite { path: path.into(), data: data.into() },
+            protocol::Request::FileWrite {
+                path: path.into(),
+                data: data.into(),
+                options,
+            },
             @ok
         )
     }
@@ -522,7 +543,11 @@ impl ChannelExt for Channel<protocol::Msg<protocol::Request>, protocol::Msg<prot
     ) -> AsyncReturn<'_, ()> {
         make_body!(
             self,
-            protocol::Request::FileWriteText { path: path.into(), text: data.into() },
+            protocol::Request::FileWrite {
+                path: path.into(),
+                data: data.into().into_bytes(),
+                options: Default::default(),
+            },
             @ok
         )
     }
@@ -590,9 +615,14 @@ mod tests {
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         match req.payload {
-            protocol::Request::FileAppend { path, data } => {
+            protocol::Request::FileWrite {
+                path,
+                data,
+                options,
+            } => {
                 assert_eq!(path, RemotePath::from("/test/path"));
                 assert_eq!(data, [1, 2, 3]);
+                assert!(options.append);
             }
             x => panic!("Unexpected request: {:?}", x),
         }
@@ -660,9 +690,14 @@ mod tests {
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         match req.payload {
-            protocol::Request::FileAppendText { path, text } => {
+            protocol::Request::FileWrite {
+                path,
+                data,
+                options,
+            } => {
                 assert_eq!(path, RemotePath::from("/test/path"));
-                assert_eq!(text, "hello");
+                assert_eq!(data, b"hello".to_vec());
+                assert!(options.append);
             }
             x => panic!("Unexpected request: {:?}", x),
         }
@@ -1080,11 +1115,12 @@ mod tests {
         let (mut transport, session) = make_session();
         let mut channel = session.clone_channel();
 
-        let task = tokio::spawn(async move { channel.read_file("/test/file").await });
+        let task =
+            tokio::spawn(async move { channel.read_file("/test/file", Default::default()).await });
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         match req.payload {
-            protocol::Request::FileRead { path } => {
+            protocol::Request::FileRead { path, .. } => {
                 assert_eq!(path, RemotePath::from("/test/file"));
             }
             x => panic!("Unexpected request: {:?}", x),
@@ -1109,7 +1145,8 @@ mod tests {
         let (mut transport, session) = make_session();
         let mut channel = session.clone_channel();
 
-        let task = tokio::spawn(async move { channel.read_file("/test/file").await });
+        let task =
+            tokio::spawn(async move { channel.read_file("/test/file", Default::default()).await });
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         transport
@@ -1136,7 +1173,7 @@ mod tests {
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         match req.payload {
-            protocol::Request::FileReadText { path } => {
+            protocol::Request::FileRead { path, .. } => {
                 assert_eq!(path, RemotePath::from("/test/file"));
             }
             x => panic!("Unexpected request: {:?}", x),
@@ -1145,8 +1182,8 @@ mod tests {
         transport
             .write_frame_for(&Response::new(
                 req.id,
-                protocol::Response::Text {
-                    data: String::from("hello world"),
+                protocol::Response::Blob {
+                    data: b"hello world".to_vec(),
                 },
             ))
             .await
@@ -1154,28 +1191,6 @@ mod tests {
 
         let result = task.await.unwrap().unwrap();
         assert_eq!(result, "hello world");
-    }
-
-    #[test(tokio::test)]
-    async fn read_file_text_should_return_error_on_mismatched_response() {
-        let (mut transport, session) = make_session();
-        let mut channel = session.clone_channel();
-
-        let task = tokio::spawn(async move { channel.read_file_text("/test/file").await });
-
-        let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
-        transport
-            .write_frame_for(&Response::new(
-                req.id,
-                protocol::Response::Blob {
-                    data: vec![1, 2, 3],
-                },
-            ))
-            .await
-            .unwrap();
-
-        let err = task.await.unwrap().unwrap_err();
-        assert_eq!(err.to_string(), "Mismatched response");
     }
 
     #[test(tokio::test)]
@@ -1432,14 +1447,22 @@ mod tests {
         let (mut transport, session) = make_session();
         let mut channel = session.clone_channel();
 
-        let task =
-            tokio::spawn(async move { channel.write_file("/test/file", vec![4, 5, 6]).await });
+        let task = tokio::spawn(async move {
+            channel
+                .write_file("/test/file", vec![4, 5, 6], Default::default())
+                .await
+        });
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         match req.payload {
-            protocol::Request::FileWrite { path, data } => {
+            protocol::Request::FileWrite {
+                path,
+                data,
+                options,
+            } => {
                 assert_eq!(path, RemotePath::from("/test/file"));
                 assert_eq!(data, [4, 5, 6]);
+                assert!(!options.append);
             }
             x => panic!("Unexpected request: {:?}", x),
         }
@@ -1457,8 +1480,11 @@ mod tests {
         let (mut transport, session) = make_session();
         let mut channel = session.clone_channel();
 
-        let task =
-            tokio::spawn(async move { channel.write_file("/test/file", vec![4, 5, 6]).await });
+        let task = tokio::spawn(async move {
+            channel
+                .write_file("/test/file", vec![4, 5, 6], Default::default())
+                .await
+        });
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         transport
@@ -1486,9 +1512,14 @@ mod tests {
 
         let req: Request<protocol::Request> = transport.read_frame_as().await.unwrap().unwrap();
         match req.payload {
-            protocol::Request::FileWriteText { path, text } => {
+            protocol::Request::FileWrite {
+                path,
+                data,
+                options,
+            } => {
                 assert_eq!(path, RemotePath::from("/test/file"));
-                assert_eq!(text, "hello world");
+                assert_eq!(data, b"hello world".to_vec());
+                assert!(!options.append);
             }
             x => panic!("Unexpected request: {:?}", x),
         }

--- a/distant-core/src/net/client/channel.rs
+++ b/distant-core/src/net/client/channel.rs
@@ -8,6 +8,7 @@ use serde::de::DeserializeOwned;
 use tokio::sync::mpsc;
 use tokio::time::Duration;
 
+use crate::net::common::utils;
 use crate::net::common::{Request, Response, UntypedRequest, UntypedResponse};
 
 mod mailbox;
@@ -157,16 +158,12 @@ fn map_to_typed_mailbox<T: Send + DeserializeOwned + 'static>(
     mailbox.map_opt(|res| match res.to_typed_response() {
         Ok(res) => Some(res),
         Err(x) => {
-            if log::log_enabled!(Level::Trace) {
-                trace!(
-                    "Invalid response payload: {}",
-                    String::from_utf8_lossy(&res.payload)
-                );
-            }
-
             error!(
-                "Unable to parse response payload into {}: {x}",
-                std::any::type_name::<T>()
+                "Unable to parse response payload into {} \
+                 ({} bytes, preview {}): {x}",
+                std::any::type_name::<T>(),
+                res.payload.len(),
+                utils::hex_preview(&res.payload, utils::HEX_PREVIEW_BYTES),
             );
             None
         }

--- a/distant-core/src/net/common/utils.rs
+++ b/distant-core/src/net/common/utils.rs
@@ -15,11 +15,38 @@ pub fn serialize_to_vec<T: Serialize>(value: &T) -> io::Result<Vec<u8>> {
         .map_err(|x| io::Error::new(io::ErrorKind::InvalidData, format!("Serialize failed: {x}")))
 }
 
+/// Maximum number of payload bytes to dump in error log previews.
+pub(crate) const HEX_PREVIEW_BYTES: usize = 64;
+
+/// Renders the first `max` bytes of `bytes` as lowercase hex. If the
+/// slice has more than `max` bytes, appends `...` to signal truncation.
+/// Safe for binary data (does not produce lossy UTF-8). Total output
+/// length is at most `2 * max + 3` characters.
+pub(crate) fn hex_preview(bytes: &[u8], max: usize) -> String {
+    let take = bytes.len().min(max);
+    let mut out = hex::encode(&bytes[..take]);
+    if bytes.len() > max {
+        out.push_str("...");
+    }
+    out
+}
+
+/// Deserialize `T` from a MessagePack byte slice.
+///
+/// # Errors
+///
+/// Returns an `io::Error` with `InvalidData` kind if the bytes cannot be
+/// decoded as `T`. The error message includes the target type name and
+/// the slice length to aid diagnosis of wire-protocol mismatches.
 pub fn deserialize_from_slice<T: DeserializeOwned>(slice: &[u8]) -> io::Result<T> {
-    rmp_serde::decode::from_slice(slice).map_err(|x| {
+    rmp_serde::decode::from_slice(slice).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("Deserialize failed: {x}"),
+            format!(
+                "Failed to deserialize {} from {} bytes: {e}",
+                std::any::type_name::<T>(),
+                slice.len(),
+            ),
         )
     })
 }
@@ -218,6 +245,76 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(300)).await;
 
             assert!(rx.try_recv().is_ok(), "Callback not triggered");
+        }
+    }
+
+    mod deserialize_from_slice {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+        struct Sample {
+            x: u32,
+        }
+
+        #[test]
+        fn should_include_type_name_and_byte_length_when_deserialize_fails() {
+            // Garbage bytes that don't decode as Sample.
+            let bytes = [0xffu8; 5];
+            let err = super::super::deserialize_from_slice::<Sample>(&bytes).unwrap_err();
+            let msg = err.to_string();
+
+            // Use the real type_name for exact matching (not a substring trap).
+            let expected_type = std::any::type_name::<Sample>();
+            assert!(
+                msg.contains(expected_type),
+                "expected type name {expected_type:?} in error, got: {msg}"
+            );
+            assert!(
+                msg.contains("5 bytes"),
+                "expected byte length in error, got: {msg}"
+            );
+        }
+
+        #[test]
+        fn should_decode_valid_payload_without_error() {
+            // Happy-path regression guard: a successful deserialize still works.
+            let bytes = rmp_serde::encode::to_vec_named(&Sample { x: 42 }).unwrap();
+            let decoded: Sample = super::super::deserialize_from_slice(&bytes).unwrap();
+            assert_eq!(decoded, Sample { x: 42 });
+        }
+    }
+
+    mod hex_preview {
+        #[test]
+        fn should_dump_entire_slice_when_shorter_than_max() {
+            assert_eq!(super::super::hex_preview(&[0x01, 0xab, 0xff], 16), "01abff");
+        }
+
+        #[test]
+        fn should_truncate_with_ellipsis_when_slice_exceeds_max() {
+            let bytes: Vec<u8> = (0..100).collect();
+            let out = super::super::hex_preview(&bytes, 4);
+            assert_eq!(out, "00010203...");
+        }
+
+        #[test]
+        fn should_not_truncate_when_slice_length_equals_max() {
+            let bytes = [0x10u8, 0x20, 0x30, 0x40];
+            assert_eq!(super::super::hex_preview(&bytes, 4), "10203040");
+        }
+
+        #[test]
+        fn should_return_empty_string_when_slice_is_empty() {
+            assert_eq!(super::super::hex_preview(&[], 16), "");
+        }
+
+        #[test]
+        fn should_render_high_bit_bytes_as_lowercase_hex() {
+            // Guards against accidentally using `{:02X}` (uppercase).
+            assert_eq!(
+                super::super::hex_preview(&[0xde, 0xad, 0xbe, 0xef], 16),
+                "deadbeef"
+            );
         }
     }
 }

--- a/distant-core/src/net/server/connection.rs
+++ b/distant-core/src/net/server/connection.rs
@@ -13,6 +13,7 @@ use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use super::{ConnectionState, RequestCtx, ServerHandler, ServerReply, ServerState, ShutdownTimer};
+use crate::net::common::utils;
 use crate::net::common::{
     Backup, Connection, Frame, Interest, Keychain, Response, Transport, UntypedRequest, Version,
 };
@@ -526,18 +527,22 @@ where
                                 tokio::spawn(async move { handler.on_request(ctx).await });
                             }
                             Err(x) => {
-                                if log::log_enabled!(Level::Debug) {
-                                    error!(
-                                        "[Conn {id}] Failed receiving {}",
-                                        String::from_utf8_lossy(&request.payload),
-                                    );
-                                }
-
-                                error!("[Conn {id}] Invalid request: {x}");
+                                error!(
+                                    "[Conn {id}] Failed to decode typed request \
+                                     ({} bytes, preview {}): {x}",
+                                    request.payload.len(),
+                                    utils::hex_preview(&request.payload, utils::HEX_PREVIEW_BYTES),
+                                );
                             }
                         },
                         Err(x) => {
-                            error!("[Conn {id}] Invalid request payload: {x}");
+                            let raw = frame.as_item();
+                            error!(
+                                "[Conn {id}] Failed to parse raw request wire format \
+                                 ({} bytes, preview {}): {x}",
+                                raw.len(),
+                                utils::hex_preview(raw, utils::HEX_PREVIEW_BYTES),
+                            );
                         }
                     },
                     Ok(None) => {

--- a/distant-core/src/protocol/common.rs
+++ b/distant-core/src/protocol/common.rs
@@ -1,6 +1,7 @@
 mod change;
 mod cmd;
 mod error;
+mod file_options;
 mod filesystem;
 mod metadata;
 mod permissions;
@@ -15,6 +16,7 @@ mod version;
 pub use change::*;
 pub use cmd::*;
 pub use error::*;
+pub use file_options::*;
 pub use filesystem::*;
 pub use metadata::*;
 pub use permissions::*;

--- a/distant-core/src/protocol/common/file_options.rs
+++ b/distant-core/src/protocol/common/file_options.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::utils;
+
+/// Options for reading a file.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
+pub struct ReadFileOptions {
+    /// Byte offset to start reading from. None means start of file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+
+    /// Number of bytes to read. None means read to end of file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub len: Option<u64>,
+}
+
+/// Options for writing a file.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
+pub struct WriteFileOptions {
+    /// Byte offset to write at. None means write from start (or end if append).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+
+    /// If true, append to end of file instead of overwriting.
+    #[serde(skip_serializing_if = "utils::is_false")]
+    pub append: bool,
+}

--- a/distant-core/src/protocol/msg.rs
+++ b/distant-core/src/protocol/msg.rs
@@ -1,12 +1,61 @@
+use std::fmt;
+use std::marker::PhantomData;
+
 use derive_more::From;
-use serde::{Deserialize, Serialize};
+use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Represents a wrapper around a message, supporting single and batch payloads.
-#[derive(Clone, Debug, From, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, From, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum Msg<T> {
     Single(T),
     Batch(Vec<T>),
+}
+
+impl<'de, T> Deserialize<'de> for Msg<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MsgVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> Visitor<'de> for MsgVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = Msg<T>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    f,
+                    "a single {} or a sequence of {} for Msg",
+                    std::any::type_name::<T>(),
+                    std::any::type_name::<T>(),
+                )
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Msg<T>, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Vec::<T>::deserialize(SeqAccessDeserializer::new(seq)).map(Msg::Batch)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Msg<T>, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                T::deserialize(MapAccessDeserializer::new(map)).map(Msg::Single)
+            }
+        }
+
+        deserializer.deserialize_any(MsgVisitor::<T>(PhantomData))
+    }
 }
 
 impl<T> Msg<T> {
@@ -110,6 +159,12 @@ mod tests {
     mod single {
         use super::*;
 
+        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct TestPayload {
+            id: u32,
+            name: String,
+        }
+
         #[test]
         fn should_be_able_to_serialize_to_json() {
             let msg = Msg::single("hello world");
@@ -120,10 +175,16 @@ mod tests {
 
         #[test]
         fn should_be_able_to_deserialize_from_json() {
-            let value = serde_json::json!("hello world");
+            let value = serde_json::json!({ "id": 1, "name": "hello world" });
 
-            let msg: Msg<String> = serde_json::from_value(value).unwrap();
-            assert_eq!(msg, Msg::single(String::from("hello world")));
+            let msg: Msg<TestPayload> = serde_json::from_value(value).unwrap();
+            assert_eq!(
+                msg,
+                Msg::single(TestPayload {
+                    id: 1,
+                    name: "hello world".into(),
+                })
+            );
         }
 
         #[test]
@@ -143,10 +204,20 @@ mod tests {
             // verify that we are not corrupting or causing issues when serializing on a
             // client/server and then trying to deserialize on the other side. This has happened
             // enough times with minor changes that we need tests to verify.
-            let buf = rmp_serde::encode::to_vec_named(&Msg::single("hello world")).unwrap();
+            let buf = rmp_serde::encode::to_vec_named(&Msg::single(TestPayload {
+                id: 1,
+                name: "hello world".into(),
+            }))
+            .unwrap();
 
-            let msg: Msg<String> = rmp_serde::decode::from_slice(&buf).unwrap();
-            assert_eq!(msg, Msg::single(String::from("hello world")));
+            let msg: Msg<TestPayload> = rmp_serde::decode::from_slice(&buf).unwrap();
+            assert_eq!(
+                msg,
+                Msg::single(TestPayload {
+                    id: 1,
+                    name: "hello world".into(),
+                })
+            );
         }
     }
 
@@ -358,6 +429,146 @@ mod tests {
             let restored: Msg<String> = serde_json::from_value(json).unwrap();
             assert!(restored.is_batch());
             assert!(restored.as_batch().unwrap().is_empty());
+        }
+    }
+
+    mod failure_paths {
+        use super::*;
+        use crate::protocol::{Msg, Request};
+
+        // Mirror production decoration exactly:
+        // `Request` / `Response` use `#[serde(rename_all = "snake_case",
+        // deny_unknown_fields, tag = "type")]`.
+        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case", deny_unknown_fields, tag = "type")]
+        enum Tagged {
+            Alpha { x: u32 },
+            Beta { y: String },
+        }
+
+        #[test]
+        fn single_should_report_inner_error_when_json_deserialize_fails() {
+            let json = serde_json::json!({ "type": "gamma" });
+            let err = serde_json::from_value::<Msg<Tagged>>(json).unwrap_err();
+            let msg = err.to_string();
+            // Real error from Tagged must surface — not the untagged collapse.
+            assert!(
+                msg.contains("gamma"),
+                "expected inner error to mention the bad variant `gamma`, got: {msg}"
+            );
+            assert!(
+                !msg.contains("did not match any variant of untagged enum"),
+                "expected real error, got untagged-enum collapse: {msg}"
+            );
+        }
+
+        #[test]
+        fn single_should_report_inner_error_when_msgpack_deserialize_fails() {
+            // Build a map-shaped msgpack payload with an unknown tag.
+            let bytes = rmp_serde::encode::to_vec_named(&serde_json::json!({
+                "type": "gamma"
+            }))
+            .unwrap();
+            let err = rmp_serde::decode::from_slice::<Msg<Tagged>>(&bytes).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("gamma"),
+                "expected msgpack inner error mentioning `gamma`, got: {msg}"
+            );
+            assert!(
+                !msg.contains("did not match any variant of untagged enum"),
+                "expected real msgpack error, got collapse: {msg}"
+            );
+        }
+
+        #[test]
+        fn single_should_report_inner_error_when_deny_unknown_fields_triggers() {
+            // Valid variant but an unknown field — deny_unknown_fields should
+            // surface the real error, not the Msg collapse.
+            let json = serde_json::json!({
+                "type": "alpha",
+                "x": 1,
+                "extra_field": 2
+            });
+            let err = serde_json::from_value::<Msg<Tagged>>(json).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("extra_field") || msg.contains("unknown field"),
+                "expected inner error mentioning the unknown field, got: {msg}"
+            );
+            assert!(
+                !msg.contains("did not match any variant of untagged enum"),
+                "expected real error, got collapse: {msg}"
+            );
+        }
+
+        #[test]
+        fn single_should_report_inner_error_for_real_request_unknown_variant() {
+            // Production path: Msg<protocol::Request> — the exact type the
+            // user's pain centers on. Locks down the production path against
+            // regressions in `Request`'s serde attributes.
+            let json = serde_json::json!({ "type": "mount_xyz_does_not_exist" });
+            let err = serde_json::from_value::<Msg<Request>>(json).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("mount_xyz_does_not_exist"),
+                "expected inner error mentioning the bad variant, got: {msg}"
+            );
+            assert!(
+                !msg.contains("did not match any variant of untagged enum"),
+                "expected real error, got collapse: {msg}"
+            );
+        }
+
+        #[test]
+        fn batch_should_report_inner_error_when_one_element_fails() {
+            // Sub-phase 1's whole point is preserving inner errors — the
+            // batch path is half the surface area. A single bad element
+            // must still propagate the real error, not the Msg collapse.
+            let json = serde_json::json!([
+                { "type": "alpha", "x": 1 },
+                { "type": "gamma" },
+            ]);
+            let err = serde_json::from_value::<Msg<Tagged>>(json).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("gamma"),
+                "expected inner error from the failing batch element, got: {msg}"
+            );
+            assert!(
+                !msg.contains("did not match any variant of untagged enum"),
+                "expected real error, got collapse: {msg}"
+            );
+        }
+
+        #[test]
+        fn single_should_roundtrip_through_json_with_custom_deserialize() {
+            let original: Msg<Tagged> = Msg::Single(Tagged::Alpha { x: 42 });
+            let value = serde_json::to_value(&original).unwrap();
+            let roundtripped: Msg<Tagged> = serde_json::from_value(value).unwrap();
+            assert_eq!(roundtripped, original);
+        }
+
+        #[test]
+        fn batch_should_roundtrip_through_json_with_custom_deserialize() {
+            let original: Msg<Tagged> = Msg::Batch(vec![
+                Tagged::Alpha { x: 1 },
+                Tagged::Beta { y: "two".into() },
+            ]);
+            let value = serde_json::to_value(&original).unwrap();
+            let roundtripped: Msg<Tagged> = serde_json::from_value(value).unwrap();
+            assert_eq!(roundtripped, original);
+        }
+
+        #[test]
+        fn batch_should_roundtrip_through_msgpack_with_custom_deserialize() {
+            let original: Msg<Tagged> = Msg::Batch(vec![
+                Tagged::Alpha { x: 1 },
+                Tagged::Beta { y: "two".into() },
+            ]);
+            let bytes = rmp_serde::encode::to_vec_named(&original).unwrap();
+            let roundtripped: Msg<Tagged> = rmp_serde::decode::from_slice(&bytes).unwrap();
+            assert_eq!(roundtripped, original);
         }
     }
 }

--- a/distant-core/src/protocol/request.rs
+++ b/distant-core/src/protocol/request.rs
@@ -4,8 +4,8 @@ use derive_more::IsVariant;
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::common::{
-    ChangeKind, Cmd, Permissions, ProcessId, PtySize, RemotePath, SearchId, SearchQuery,
-    SetPermissionsOptions, TunnelId,
+    ChangeKind, Cmd, Permissions, ProcessId, PtySize, ReadFileOptions, RemotePath, SearchId,
+    SearchQuery, SetPermissionsOptions, TunnelId, WriteFileOptions,
 };
 use crate::protocol::utils;
 
@@ -20,17 +20,14 @@ pub enum Request {
     FileRead {
         /// The path to the file on the remote machine
         path: RemotePath,
+
+        /// Options controlling the read operation
+        #[serde(default)]
+        options: ReadFileOptions,
     },
 
-    /// Reads a file from the specified path on the remote machine
-    /// and treats the contents as text
-    FileReadText {
-        /// The path to the file on the remote machine
-        path: RemotePath,
-    },
-
-    /// Writes a file, creating it if it does not exist, and overwriting any existing content
-    /// on the remote machine
+    /// Writes a file, creating it if it does not exist, on the remote machine.
+    /// Supports overwriting, appending, and offset-based writes via options.
     FileWrite {
         /// The path to the file on the remote machine
         path: RemotePath,
@@ -38,35 +35,10 @@ pub enum Request {
         /// Data for server-side writing of content
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
-    },
 
-    /// Writes a file using text instead of bytes, creating it if it does not exist,
-    /// and overwriting any existing content on the remote machine
-    FileWriteText {
-        /// The path to the file on the remote machine
-        path: RemotePath,
-
-        /// Data for server-side writing of content
-        text: String,
-    },
-
-    /// Appends to a file, creating it if it does not exist, on the remote machine
-    FileAppend {
-        /// The path to the file on the remote machine
-        path: RemotePath,
-
-        /// Data for server-side writing of content
-        #[serde(with = "serde_bytes")]
-        data: Vec<u8>,
-    },
-
-    /// Appends text to a file, creating it if it does not exist, on the remote machine
-    FileAppendText {
-        /// The path to the file on the remote machine
-        path: RemotePath,
-
-        /// Data for server-side writing of content
-        text: String,
+        /// Options controlling the write operation
+        #[serde(default)]
+        options: WriteFileOptions,
     },
 
     /// Reads a directory from the specified path on the remote machine
@@ -308,6 +280,7 @@ mod tests {
         fn should_be_able_to_serialize_to_json() {
             let payload = Request::FileRead {
                 path: RemotePath::new("path"),
+                options: Default::default(),
             };
 
             let value = serde_json::to_value(payload).unwrap();
@@ -316,6 +289,7 @@ mod tests {
                 serde_json::json!({
                     "type": "file_read",
                     "path": "path",
+                    "options": {},
                 })
             );
         }
@@ -332,6 +306,7 @@ mod tests {
                 payload,
                 Request::FileRead {
                     path: RemotePath::new("path"),
+                    options: Default::default(),
                 }
             );
         }
@@ -340,6 +315,7 @@ mod tests {
         fn should_be_able_to_serialize_to_msgpack() {
             let payload = Request::FileRead {
                 path: RemotePath::new("path"),
+                options: Default::default(),
             };
 
             // NOTE: We don't actually check the output here because it's an implementation detail
@@ -357,6 +333,7 @@ mod tests {
             // enough times with minor changes that we need tests to verify.
             let buf = rmp_serde::encode::to_vec_named(&Request::FileRead {
                 path: RemotePath::new("path"),
+                options: Default::default(),
             })
             .unwrap();
 
@@ -365,75 +342,79 @@ mod tests {
                 payload,
                 Request::FileRead {
                     path: RemotePath::new("path"),
+                    options: Default::default(),
                 }
             );
         }
-    }
-
-    mod file_read_text {
-        use super::*;
 
         #[test]
-        fn should_be_able_to_serialize_to_json() {
-            let payload = Request::FileReadText {
+        fn should_serialize_options_fields_when_set() {
+            let payload = Request::FileRead {
                 path: RemotePath::new("path"),
+                options: ReadFileOptions {
+                    offset: Some(100),
+                    len: Some(256),
+                },
             };
 
             let value = serde_json::to_value(payload).unwrap();
             assert_eq!(
                 value,
                 serde_json::json!({
-                    "type": "file_read_text",
+                    "type": "file_read",
                     "path": "path",
+                    "options": {
+                        "offset": 100,
+                        "len": 256,
+                    },
                 })
             );
         }
 
         #[test]
-        fn should_be_able_to_deserialize_from_json() {
+        fn should_deserialize_options_fields_when_set() {
             let value = serde_json::json!({
-                "type": "file_read_text",
+                "type": "file_read",
                 "path": "path",
+                "options": {
+                    "offset": 100,
+                    "len": 256,
+                },
             });
 
             let payload: Request = serde_json::from_value(value).unwrap();
             assert_eq!(
                 payload,
-                Request::FileReadText {
+                Request::FileRead {
                     path: RemotePath::new("path"),
+                    options: ReadFileOptions {
+                        offset: Some(100),
+                        len: Some(256),
+                    },
                 }
             );
         }
 
         #[test]
-        fn should_be_able_to_serialize_to_msgpack() {
-            let payload = Request::FileReadText {
+        fn should_be_able_to_roundtrip_options_via_msgpack() {
+            let buf = rmp_serde::encode::to_vec_named(&Request::FileRead {
                 path: RemotePath::new("path"),
-            };
-
-            // NOTE: We don't actually check the output here because it's an implementation detail
-            // and could change as we change how serialization is done. This is merely to verify
-            // that we can serialize since there are times when serde fails to serialize at
-            // runtime.
-            let _ = rmp_serde::encode::to_vec_named(&payload).unwrap();
-        }
-
-        #[test]
-        fn should_be_able_to_deserialize_from_msgpack() {
-            // NOTE: It may seem odd that we are serializing just to deserialize, but this is to
-            // verify that we are not corrupting or causing issues when serializing on a
-            // client/server and then trying to deserialize on the other side. This has happened
-            // enough times with minor changes that we need tests to verify.
-            let buf = rmp_serde::encode::to_vec_named(&Request::FileReadText {
-                path: RemotePath::new("path"),
+                options: ReadFileOptions {
+                    offset: Some(100),
+                    len: Some(256),
+                },
             })
             .unwrap();
 
             let payload: Request = rmp_serde::decode::from_slice(&buf).unwrap();
             assert_eq!(
                 payload,
-                Request::FileReadText {
+                Request::FileRead {
                     path: RemotePath::new("path"),
+                    options: ReadFileOptions {
+                        offset: Some(100),
+                        len: Some(256),
+                    },
                 }
             );
         }
@@ -447,6 +428,7 @@ mod tests {
             let payload = Request::FileWrite {
                 path: RemotePath::new("path"),
                 data: vec![0, 1, 2, u8::MAX],
+                options: Default::default(),
             };
 
             let value = serde_json::to_value(payload).unwrap();
@@ -456,6 +438,7 @@ mod tests {
                     "type": "file_write",
                     "path": "path",
                     "data": [0, 1, 2, u8::MAX],
+                    "options": {},
                 })
             );
         }
@@ -474,6 +457,7 @@ mod tests {
                 Request::FileWrite {
                     path: RemotePath::new("path"),
                     data: vec![0, 1, 2, u8::MAX],
+                    options: Default::default(),
                 }
             );
         }
@@ -483,6 +467,7 @@ mod tests {
             let payload = Request::FileWrite {
                 path: RemotePath::new("path"),
                 data: vec![0, 1, 2, u8::MAX],
+                options: Default::default(),
             };
 
             // NOTE: We don't actually check the output here because it's an implementation detail
@@ -501,6 +486,7 @@ mod tests {
             let buf = rmp_serde::encode::to_vec_named(&Request::FileWrite {
                 path: RemotePath::new("path"),
                 data: vec![0, 1, 2, u8::MAX],
+                options: Default::default(),
             })
             .unwrap();
 
@@ -510,234 +496,83 @@ mod tests {
                 Request::FileWrite {
                     path: RemotePath::new("path"),
                     data: vec![0, 1, 2, u8::MAX],
+                    options: Default::default(),
                 }
             );
         }
-    }
-
-    mod file_write_text {
-        use super::*;
 
         #[test]
-        fn should_be_able_to_serialize_to_json() {
-            let payload = Request::FileWriteText {
+        fn should_serialize_append_option_when_true() {
+            let payload = Request::FileWrite {
                 path: RemotePath::new("path"),
-                text: String::from("text"),
+                data: vec![0, 1, 2],
+                options: WriteFileOptions {
+                    offset: None,
+                    append: true,
+                },
             };
 
             let value = serde_json::to_value(payload).unwrap();
             assert_eq!(
                 value,
                 serde_json::json!({
-                    "type": "file_write_text",
+                    "type": "file_write",
                     "path": "path",
-                    "text": "text",
+                    "data": [0, 1, 2],
+                    "options": {
+                        "append": true,
+                    },
                 })
             );
         }
 
         #[test]
-        fn should_be_able_to_deserialize_from_json() {
+        fn should_deserialize_append_option_when_true() {
             let value = serde_json::json!({
-                "type": "file_write_text",
+                "type": "file_write",
                 "path": "path",
-                "text": "text",
+                "data": [0, 1, 2],
+                "options": {
+                    "append": true,
+                },
             });
 
             let payload: Request = serde_json::from_value(value).unwrap();
             assert_eq!(
                 payload,
-                Request::FileWriteText {
+                Request::FileWrite {
                     path: RemotePath::new("path"),
-                    text: String::from("text"),
+                    data: vec![0, 1, 2],
+                    options: WriteFileOptions {
+                        offset: None,
+                        append: true,
+                    },
                 }
             );
         }
 
         #[test]
-        fn should_be_able_to_serialize_to_msgpack() {
-            let payload = Request::FileWriteText {
+        fn should_be_able_to_roundtrip_append_option_via_msgpack() {
+            let buf = rmp_serde::encode::to_vec_named(&Request::FileWrite {
                 path: RemotePath::new("path"),
-                text: String::from("text"),
-            };
-
-            // NOTE: We don't actually check the output here because it's an implementation detail
-            // and could change as we change how serialization is done. This is merely to verify
-            // that we can serialize since there are times when serde fails to serialize at
-            // runtime.
-            let _ = rmp_serde::encode::to_vec_named(&payload).unwrap();
-        }
-
-        #[test]
-        fn should_be_able_to_deserialize_from_msgpack() {
-            // NOTE: It may seem odd that we are serializing just to deserialize, but this is to
-            // verify that we are not corrupting or causing issues when serializing on a
-            // client/server and then trying to deserialize on the other side. This has happened
-            // enough times with minor changes that we need tests to verify.
-            let buf = rmp_serde::encode::to_vec_named(&Request::FileWriteText {
-                path: RemotePath::new("path"),
-                text: String::from("text"),
+                data: vec![0, 1, 2],
+                options: WriteFileOptions {
+                    offset: None,
+                    append: true,
+                },
             })
             .unwrap();
 
             let payload: Request = rmp_serde::decode::from_slice(&buf).unwrap();
             assert_eq!(
                 payload,
-                Request::FileWriteText {
+                Request::FileWrite {
                     path: RemotePath::new("path"),
-                    text: String::from("text"),
-                }
-            );
-        }
-    }
-
-    mod file_append {
-        use super::*;
-
-        #[test]
-        fn should_be_able_to_serialize_to_json() {
-            let payload = Request::FileAppend {
-                path: RemotePath::new("path"),
-                data: vec![0, 1, 2, u8::MAX],
-            };
-
-            let value = serde_json::to_value(payload).unwrap();
-            assert_eq!(
-                value,
-                serde_json::json!({
-                    "type": "file_append",
-                    "path": "path",
-                    "data": [0, 1, 2, u8::MAX],
-                })
-            );
-        }
-
-        #[test]
-        fn should_be_able_to_deserialize_from_json() {
-            let value = serde_json::json!({
-                "type": "file_append",
-                "path": "path",
-                "data": [0, 1, 2, u8::MAX],
-            });
-
-            let payload: Request = serde_json::from_value(value).unwrap();
-            assert_eq!(
-                payload,
-                Request::FileAppend {
-                    path: RemotePath::new("path"),
-                    data: vec![0, 1, 2, u8::MAX],
-                }
-            );
-        }
-
-        #[test]
-        fn should_be_able_to_serialize_to_msgpack() {
-            let payload = Request::FileAppend {
-                path: RemotePath::new("path"),
-                data: vec![0, 1, 2, u8::MAX],
-            };
-
-            // NOTE: We don't actually check the output here because it's an implementation detail
-            // and could change as we change how serialization is done. This is merely to verify
-            // that we can serialize since there are times when serde fails to serialize at
-            // runtime.
-            let _ = rmp_serde::encode::to_vec_named(&payload).unwrap();
-        }
-
-        #[test]
-        fn should_be_able_to_deserialize_from_msgpack() {
-            // NOTE: It may seem odd that we are serializing just to deserialize, but this is to
-            // verify that we are not corrupting or causing issues when serializing on a
-            // client/server and then trying to deserialize on the other side. This has happened
-            // enough times with minor changes that we need tests to verify.
-            let buf = rmp_serde::encode::to_vec_named(&Request::FileAppend {
-                path: RemotePath::new("path"),
-                data: vec![0, 1, 2, u8::MAX],
-            })
-            .unwrap();
-
-            let payload: Request = rmp_serde::decode::from_slice(&buf).unwrap();
-            assert_eq!(
-                payload,
-                Request::FileAppend {
-                    path: RemotePath::new("path"),
-                    data: vec![0, 1, 2, u8::MAX],
-                }
-            );
-        }
-    }
-
-    mod file_append_text {
-        use super::*;
-
-        #[test]
-        fn should_be_able_to_serialize_to_json() {
-            let payload = Request::FileAppendText {
-                path: RemotePath::new("path"),
-                text: String::from("text"),
-            };
-
-            let value = serde_json::to_value(payload).unwrap();
-            assert_eq!(
-                value,
-                serde_json::json!({
-                    "type": "file_append_text",
-                    "path": "path",
-                    "text": "text",
-                })
-            );
-        }
-
-        #[test]
-        fn should_be_able_to_deserialize_from_json() {
-            let value = serde_json::json!({
-                "type": "file_append_text",
-                "path": "path",
-                "text": "text",
-            });
-
-            let payload: Request = serde_json::from_value(value).unwrap();
-            assert_eq!(
-                payload,
-                Request::FileAppendText {
-                    path: RemotePath::new("path"),
-                    text: String::from("text"),
-                }
-            );
-        }
-
-        #[test]
-        fn should_be_able_to_serialize_to_msgpack() {
-            let payload = Request::FileAppendText {
-                path: RemotePath::new("path"),
-                text: String::from("text"),
-            };
-
-            // NOTE: We don't actually check the output here because it's an implementation detail
-            // and could change as we change how serialization is done. This is merely to verify
-            // that we can serialize since there are times when serde fails to serialize at
-            // runtime.
-            let _ = rmp_serde::encode::to_vec_named(&payload).unwrap();
-        }
-
-        #[test]
-        fn should_be_able_to_deserialize_from_msgpack() {
-            // NOTE: It may seem odd that we are serializing just to deserialize, but this is to
-            // verify that we are not corrupting or causing issues when serializing on a
-            // client/server and then trying to deserialize on the other side. This has happened
-            // enough times with minor changes that we need tests to verify.
-            let buf = rmp_serde::encode::to_vec_named(&Request::FileAppendText {
-                path: RemotePath::new("path"),
-                text: String::from("text"),
-            })
-            .unwrap();
-
-            let payload: Request = rmp_serde::decode::from_slice(&buf).unwrap();
-            assert_eq!(
-                payload,
-                Request::FileAppendText {
-                    path: RemotePath::new("path"),
-                    text: String::from("text"),
+                    data: vec![0, 1, 2],
+                    options: WriteFileOptions {
+                        offset: None,
+                        append: true,
+                    },
                 }
             );
         }

--- a/distant-core/tests/api_tests.rs
+++ b/distant-core/tests/api_tests.rs
@@ -7,7 +7,7 @@ use distant_core::net::auth::{DummyAuthHandler, Verifier};
 use distant_core::net::client::Client as NetClient;
 use distant_core::net::common::{InmemoryTransport, OneshotListener, Version};
 use distant_core::net::server::{Server, ServerRef};
-use distant_core::protocol::{PROTOCOL_VERSION, RemotePath};
+use distant_core::protocol::{PROTOCOL_VERSION, ReadFileOptions, RemotePath};
 use distant_core::{Api, ApiServerHandler, ChannelExt, Client, Ctx};
 
 /// Stands up an inmemory client and server using the given api.
@@ -50,14 +50,22 @@ mod single {
         struct TestApi;
 
         impl Api for TestApi {
-            async fn read_file(&self, _ctx: Ctx, _path: RemotePath) -> io::Result<Vec<u8>> {
+            async fn read_file(
+                &self,
+                _ctx: Ctx,
+                _path: RemotePath,
+                _options: ReadFileOptions,
+            ) -> io::Result<Vec<u8>> {
                 Err(io::Error::new(io::ErrorKind::NotFound, "test error"))
             }
         }
 
         let (mut client, _server) = setup(TestApi).await;
 
-        let error = client.read_file(RemotePath::new("file")).await.unwrap_err();
+        let error = client
+            .read_file(RemotePath::new("file"), Default::default())
+            .await
+            .unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::NotFound);
         assert_eq!(error.to_string(), "test error");
     }
@@ -67,14 +75,22 @@ mod single {
         struct TestApi;
 
         impl Api for TestApi {
-            async fn read_file(&self, _ctx: Ctx, _path: RemotePath) -> io::Result<Vec<u8>> {
+            async fn read_file(
+                &self,
+                _ctx: Ctx,
+                _path: RemotePath,
+                _options: ReadFileOptions,
+            ) -> io::Result<Vec<u8>> {
                 Ok(b"hello world".to_vec())
             }
         }
 
         let (mut client, _server) = setup(TestApi).await;
 
-        let contents = client.read_file(RemotePath::new("file")).await.unwrap();
+        let contents = client
+            .read_file(RemotePath::new("file"), Default::default())
+            .await
+            .unwrap();
         assert_eq!(contents, b"hello world");
     }
 }
@@ -93,7 +109,12 @@ mod batch_parallel {
         struct TestApi;
 
         impl Api for TestApi {
-            async fn read_file(&self, _ctx: Ctx, path: RemotePath) -> io::Result<Vec<u8>> {
+            async fn read_file(
+                &self,
+                _ctx: Ctx,
+                path: RemotePath,
+                _options: ReadFileOptions,
+            ) -> io::Result<Vec<u8>> {
                 if path.as_str() == "slow" {
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
@@ -108,12 +129,15 @@ mod batch_parallel {
         let request = Request::new(Msg::batch([
             RequestPayload::FileRead {
                 path: RemotePath::new("file1"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("slow"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("file2"),
+                options: Default::default(),
             },
         ]));
 
@@ -145,7 +169,12 @@ mod batch_parallel {
         struct TestApi;
 
         impl Api for TestApi {
-            async fn read_file(&self, _ctx: Ctx, path: RemotePath) -> io::Result<Vec<u8>> {
+            async fn read_file(
+                &self,
+                _ctx: Ctx,
+                path: RemotePath,
+                _options: ReadFileOptions,
+            ) -> io::Result<Vec<u8>> {
                 if path.as_str() == "fail" {
                     return Err(io::Error::other("test error"));
                 }
@@ -159,12 +188,15 @@ mod batch_parallel {
         let request = Request::new(Msg::batch([
             RequestPayload::FileRead {
                 path: RemotePath::new("file1"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("fail"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("file2"),
+                options: Default::default(),
             },
         ]));
 
@@ -208,7 +240,12 @@ mod batch_sequence {
         struct TestApi;
 
         impl Api for TestApi {
-            async fn read_file(&self, _ctx: Ctx, path: RemotePath) -> io::Result<Vec<u8>> {
+            async fn read_file(
+                &self,
+                _ctx: Ctx,
+                path: RemotePath,
+                _options: ReadFileOptions,
+            ) -> io::Result<Vec<u8>> {
                 if path.as_str() == "slow" {
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
@@ -223,12 +260,15 @@ mod batch_sequence {
         let mut request = Request::new(Msg::batch([
             RequestPayload::FileRead {
                 path: RemotePath::new("file1"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("slow"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("file2"),
+                options: Default::default(),
             },
         ]));
 
@@ -263,7 +303,12 @@ mod batch_sequence {
         struct TestApi;
 
         impl Api for TestApi {
-            async fn read_file(&self, _ctx: Ctx, path: RemotePath) -> io::Result<Vec<u8>> {
+            async fn read_file(
+                &self,
+                _ctx: Ctx,
+                path: RemotePath,
+                _options: ReadFileOptions,
+            ) -> io::Result<Vec<u8>> {
                 if path.as_str() == "fail" {
                     return Err(io::Error::other("test error"));
                 }
@@ -277,12 +322,15 @@ mod batch_sequence {
         let mut request = Request::new(Msg::batch([
             RequestPayload::FileRead {
                 path: RemotePath::new("file1"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("fail"),
+                options: Default::default(),
             },
             RequestPayload::FileRead {
                 path: RemotePath::new("file2"),
+                options: Default::default(),
             },
         ]));
 

--- a/distant-docker/src/api.rs
+++ b/distant-docker/src/api.rs
@@ -15,9 +15,9 @@ use distant_core::constants::TUNNEL_CHANNEL_CAPACITY;
 use distant_core::net::server::Reply;
 use distant_core::protocol::{
     ChangeKind, DirEntry, Environment, FileType, Metadata, PROTOCOL_VERSION, Permissions,
-    ProcessId, PtySize, RemotePath, Response, SearchId, SearchQuery, SearchQueryTarget,
-    SetPermissionsOptions, StatusInfo, SystemInfo, TunnelDirection, TunnelId, TunnelInfo,
-    UnixMetadata, Version,
+    ProcessId, PtySize, ReadFileOptions, RemotePath, Response, SearchId, SearchQuery,
+    SearchQueryTarget, SetPermissionsOptions, StatusInfo, SystemInfo, TunnelDirection, TunnelId,
+    TunnelInfo, UnixMetadata, Version, WriteFileOptions,
 };
 use distant_core::{Api, Ctx};
 use futures::StreamExt;
@@ -218,6 +218,7 @@ impl Api for DockerApi {
         &self,
         _ctx: Ctx,
         path: RemotePath,
+        options: ReadFileOptions,
     ) -> impl std::future::Future<Output = io::Result<Vec<u8>>> + Send {
         async move {
             let path_str = path.as_str();
@@ -233,23 +234,23 @@ impl Api for DockerApi {
                 ));
             }
 
-            utils::tar_read_file(self.client.inner(), &self.container, path_str).await
-        }
-    }
+            let data = utils::tar_read_file(self.client.inner(), &self.container, path_str).await?;
 
-    fn read_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-    ) -> impl std::future::Future<Output = io::Result<String>> + Send {
-        async move {
-            let data = self.read_file(ctx, path).await?;
-            String::from_utf8(data).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("File is not valid UTF-8: {}", e),
-                )
-            })
+            // Apply byte-range slicing when offset or len is specified
+            match (options.offset, options.len) {
+                (None, None) => Ok(data),
+                (offset, len) => {
+                    let start = offset.unwrap_or(0) as usize;
+                    if start >= data.len() {
+                        return Ok(Vec::new());
+                    }
+                    let end = match len {
+                        Some(n) => data.len().min(start + n as usize),
+                        None => data.len(),
+                    };
+                    Ok(data[start..end].to_vec())
+                }
+            }
         }
     }
 
@@ -258,68 +259,60 @@ impl Api for DockerApi {
         _ctx: Ctx,
         path: RemotePath,
         data: Vec<u8>,
+        options: WriteFileOptions,
     ) -> impl std::future::Future<Output = io::Result<()>> + Send {
         async move {
             let path_str = path.as_str();
-            utils::tar_write_file(self.client.inner(), &self.container, path_str, &data).await
-        }
-    }
 
-    fn write_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: String,
-    ) -> impl std::future::Future<Output = io::Result<()>> + Send {
-        async move { self.write_file(ctx, path, data.into_bytes()).await }
-    }
+            if options.append {
+                // Primary: try exec-based append
+                let quoted = path_str.to_string();
+                let result = utils::execute_with_stdin(
+                    self.client.inner(),
+                    &self.container,
+                    &[
+                        "sh",
+                        "-c",
+                        &format!("cat >> {}", utils::shell_quote(&quoted)),
+                    ],
+                    &data,
+                    self.user(),
+                )
+                .await;
 
-    fn append_file(
-        &self,
-        _ctx: Ctx,
-        path: RemotePath,
-        data: Vec<u8>,
-    ) -> impl std::future::Future<Output = io::Result<()>> + Send {
-        async move {
-            let path_str = path.as_str().to_string();
+                if let Ok(output) = result
+                    && output.success()
+                {
+                    return Ok(());
+                }
 
-            // Primary: try exec-based append
-            let result = utils::execute_with_stdin(
-                self.client.inner(),
-                &self.container,
-                &[
-                    "sh",
-                    "-c",
-                    &format!("cat >> {}", utils::shell_quote(&path_str)),
-                ],
-                &data,
-                self.user(),
-            )
-            .await;
+                // Fallback: tar-read, append in memory, tar-write back
+                let existing = utils::tar_read_file(self.client.inner(), &self.container, path_str)
+                    .await
+                    .unwrap_or_default();
+                let mut combined = existing;
+                combined.extend_from_slice(&data);
+                utils::tar_write_file(self.client.inner(), &self.container, path_str, &combined)
+                    .await
+            } else if let Some(offset) = options.offset {
+                // Offset write: read existing content, patch the range, write back.
+                let mut existing =
+                    utils::tar_read_file(self.client.inner(), &self.container, path_str)
+                        .await
+                        .unwrap_or_default();
 
-            if let Ok(output) = result
-                && output.success()
-            {
-                return Ok(());
+                let end = offset as usize + data.len();
+                if end > existing.len() {
+                    existing.resize(end, 0);
+                }
+                existing[offset as usize..end].copy_from_slice(&data);
+
+                utils::tar_write_file(self.client.inner(), &self.container, path_str, &existing)
+                    .await
+            } else {
+                utils::tar_write_file(self.client.inner(), &self.container, path_str, &data).await
             }
-
-            // Fallback: tar-read, append in memory, tar-write back
-            let existing = utils::tar_read_file(self.client.inner(), &self.container, &path_str)
-                .await
-                .unwrap_or_default();
-            let mut combined = existing;
-            combined.extend_from_slice(&data);
-            utils::tar_write_file(self.client.inner(), &self.container, &path_str, &combined).await
         }
-    }
-
-    fn append_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: String,
-    ) -> impl std::future::Future<Output = io::Result<()>> + Send {
-        async move { self.append_file(ctx, path, data.into_bytes()).await }
     }
 
     fn read_dir(

--- a/distant-docker/tests/docker/client.rs
+++ b/distant-docker/tests/docker/client.rs
@@ -28,10 +28,13 @@ async fn write_file_and_read_file_should_roundtrip(#[future] client: Option<Ctx<
     let data = b"hello from distant!";
 
     client
-        .write_file(path.clone(), data.to_vec())
+        .write_file(path.clone(), data.to_vec(), Default::default())
         .await
         .unwrap();
-    let result = client.read_file(path.clone()).await.unwrap();
+    let result = client
+        .read_file(path.clone(), Default::default())
+        .await
+        .unwrap();
     assert_eq!(result, data);
 
     let _ = client.remove(path, false).await;
@@ -43,7 +46,7 @@ async fn read_file_should_fail_if_missing(#[future] client: Option<Ctx<Client>>)
     let mut client = skip_if_no_docker!(client.await);
     let path = test_temp_dir().join("distant-test-nonexistent-file.txt");
     let err = client
-        .read_file(path)
+        .read_file(path, Default::default())
         .await
         .expect_err("Expected error reading nonexistent file");
     let err_msg = err.to_string().to_lowercase();
@@ -81,7 +84,7 @@ async fn append_file_should_append_data(#[future] client: Option<Ctx<Client>>) {
     let path = test_temp_dir().join("distant-test-append.txt");
 
     client
-        .write_file(path.clone(), b"hello".to_vec())
+        .write_file(path.clone(), b"hello".to_vec(), Default::default())
         .await
         .unwrap();
     client
@@ -89,7 +92,10 @@ async fn append_file_should_append_data(#[future] client: Option<Ctx<Client>>) {
         .await
         .unwrap();
 
-    let result = client.read_file(path.clone()).await.unwrap();
+    let result = client
+        .read_file(path.clone(), Default::default())
+        .await
+        .unwrap();
     assert_eq!(result, b"hello world");
 
     let _ = client.remove(path, false).await;
@@ -140,11 +146,11 @@ async fn read_dir_should_list_entries(#[future] client: Option<Ctx<Client>>) {
     let _ = client.remove(dir.clone(), true).await;
     client.create_dir(dir.clone(), false).await.unwrap();
     client
-        .write_file(dir.join("file1.txt"), b"a".to_vec())
+        .write_file(dir.join("file1.txt"), b"a".to_vec(), Default::default())
         .await
         .unwrap();
     client
-        .write_file(dir.join("file2.txt"), b"b".to_vec())
+        .write_file(dir.join("file2.txt"), b"b".to_vec(), Default::default())
         .await
         .unwrap();
 
@@ -178,12 +184,15 @@ async fn copy_should_duplicate_file(#[future] client: Option<Ctx<Client>>) {
     let _ = client.remove(dst.clone(), false).await;
 
     client
-        .write_file(src.clone(), b"copy me".to_vec())
+        .write_file(src.clone(), b"copy me".to_vec(), Default::default())
         .await
         .unwrap();
     client.copy(src.clone(), dst.clone()).await.unwrap();
 
-    let result = client.read_file(dst.clone()).await.unwrap();
+    let result = client
+        .read_file(dst.clone(), Default::default())
+        .await
+        .unwrap();
     assert_eq!(result, b"copy me");
 
     let _ = client.remove(src, false).await;
@@ -200,7 +209,7 @@ async fn rename_should_move_file(#[future] client: Option<Ctx<Client>>) {
     let _ = client.remove(dst.clone(), false).await;
 
     client
-        .write_file(src.clone(), b"rename me".to_vec())
+        .write_file(src.clone(), b"rename me".to_vec(), Default::default())
         .await
         .unwrap();
     client.rename(src.clone(), dst.clone()).await.unwrap();
@@ -208,7 +217,10 @@ async fn rename_should_move_file(#[future] client: Option<Ctx<Client>>) {
     let exists_src = client.exists(src).await.unwrap();
     assert!(!exists_src, "Source should not exist after rename");
 
-    let result = client.read_file(dst.clone()).await.unwrap();
+    let result = client
+        .read_file(dst.clone(), Default::default())
+        .await
+        .unwrap();
     assert_eq!(result, b"rename me");
 
     let _ = client.remove(dst, false).await;
@@ -236,7 +248,7 @@ async fn metadata_should_return_file_info(#[future] client: Option<Ctx<Client>>)
     let path = test_temp_dir().join("distant-test-metadata.txt");
 
     client
-        .write_file(path.clone(), b"metadata test".to_vec())
+        .write_file(path.clone(), b"metadata test".to_vec(), Default::default())
         .await
         .unwrap();
 
@@ -277,7 +289,7 @@ async fn remove_should_delete_file(#[future] client: Option<Ctx<Client>>) {
     let path = test_temp_dir().join("distant-test-remove.txt");
 
     client
-        .write_file(path.clone(), b"remove me".to_vec())
+        .write_file(path.clone(), b"remove me".to_vec(), Default::default())
         .await
         .unwrap();
     client.remove(path.clone(), false).await.unwrap();
@@ -296,7 +308,7 @@ async fn remove_should_delete_directory_recursively(#[future] client: Option<Ctx
     let sub = dir.join("sub");
     client.create_dir(sub.clone(), true).await.unwrap();
     client
-        .write_file(sub.join("file.txt"), b"nested".to_vec())
+        .write_file(sub.join("file.txt"), b"nested".to_vec(), Default::default())
         .await
         .unwrap();
 
@@ -450,7 +462,10 @@ async fn search_path_should_find_file_by_name(#[future] client: Option<Ctx<Clien
 
     let _ = client.remove(dir.clone(), true).await;
     client.create_dir(dir.clone(), true).await.unwrap();
-    client.write_file(file, b"content".to_vec()).await.unwrap();
+    client
+        .write_file(file, b"content".to_vec(), Default::default())
+        .await
+        .unwrap();
 
     let query = distant_core::protocol::SearchQuery::path(
         SearchQueryCondition::Contains {

--- a/distant-host/src/api.rs
+++ b/distant-host/src/api.rs
@@ -4,13 +4,13 @@ use std::{env, io};
 
 use distant_core::protocol::{
     ChangeKind, ChangeKindSet, DirEntry, Environment, FileType, Metadata, PROTOCOL_VERSION,
-    Permissions, ProcessId, PtySize, RemotePath, SearchId, SearchQuery, SetPermissionsOptions,
-    StatusInfo, SystemInfo, TunnelId, Version, semver,
+    Permissions, ProcessId, PtySize, ReadFileOptions, RemotePath, SearchId, SearchQuery,
+    SetPermissionsOptions, StatusInfo, SystemInfo, TunnelId, Version, WriteFileOptions, semver,
 };
 use distant_core::{Api as DistantApi, Ctx};
 use ignore::{DirEntry as WalkDirEntry, WalkBuilder};
 use log::*;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use walkdir::WalkDir;
 
 use crate::config::Config;
@@ -37,74 +37,77 @@ impl Api {
 }
 
 impl DistantApi for Api {
-    async fn read_file(&self, ctx: Ctx, path: RemotePath) -> io::Result<Vec<u8>> {
+    async fn read_file(
+        &self,
+        ctx: Ctx,
+        path: RemotePath,
+        options: ReadFileOptions,
+    ) -> io::Result<Vec<u8>> {
         let path = PathBuf::from(path);
         debug!(
-            "[Conn {}] Reading bytes from file {:?}",
-            ctx.connection_id, path
+            "[Conn {}] Reading bytes from file {:?} (options: {:?})",
+            ctx.connection_id, path, options
         );
 
-        tokio::fs::read(path).await
+        if options.offset.is_none() && options.len.is_none() {
+            return tokio::fs::read(path).await;
+        }
+
+        let mut file = tokio::fs::File::open(path).await?;
+
+        if let Some(offset) = options.offset {
+            file.seek(io::SeekFrom::Start(offset)).await?;
+        }
+
+        match options.len {
+            Some(len) => {
+                let mut buf = vec![0u8; len as usize];
+                let n = file.read(&mut buf).await?;
+                buf.truncate(n);
+                Ok(buf)
+            }
+            None => {
+                let mut buf = Vec::new();
+                file.read_to_end(&mut buf).await?;
+                Ok(buf)
+            }
+        }
     }
 
-    async fn read_file_text(&self, ctx: Ctx, path: RemotePath) -> io::Result<String> {
+    async fn write_file(
+        &self,
+        ctx: Ctx,
+        path: RemotePath,
+        data: Vec<u8>,
+        options: WriteFileOptions,
+    ) -> io::Result<()> {
         let path = PathBuf::from(path);
         debug!(
-            "[Conn {}] Reading text from file {:?}",
-            ctx.connection_id, path
+            "[Conn {}] Writing bytes to file {:?} (options: {:?})",
+            ctx.connection_id, path, options
         );
 
-        tokio::fs::read_to_string(path).await
-    }
+        if options.append {
+            let mut file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .await?;
+            return file.write_all(&data).await;
+        }
 
-    async fn write_file(&self, ctx: Ctx, path: RemotePath, data: Vec<u8>) -> io::Result<()> {
-        let path = PathBuf::from(path);
-        debug!(
-            "[Conn {}] Writing bytes to file {:?}",
-            ctx.connection_id, path
-        );
+        if let Some(offset) = options.offset {
+            let mut file = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path)
+                .await?;
+            file.seek(io::SeekFrom::Start(offset)).await?;
+            return file.write_all(&data).await;
+        }
 
         tokio::fs::write(path, data).await
-    }
-
-    async fn write_file_text(&self, ctx: Ctx, path: RemotePath, data: String) -> io::Result<()> {
-        let path = PathBuf::from(path);
-        debug!(
-            "[Conn {}] Writing text to file {:?}",
-            ctx.connection_id, path
-        );
-
-        tokio::fs::write(path, data).await
-    }
-
-    async fn append_file(&self, ctx: Ctx, path: RemotePath, data: Vec<u8>) -> io::Result<()> {
-        let path = PathBuf::from(path);
-        debug!(
-            "[Conn {}] Appending bytes to file {:?}",
-            ctx.connection_id, path
-        );
-
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await?;
-        file.write_all(data.as_ref()).await
-    }
-
-    async fn append_file_text(&self, ctx: Ctx, path: RemotePath, data: String) -> io::Result<()> {
-        let path = PathBuf::from(path);
-        debug!(
-            "[Conn {}] Appending text to file {:?}",
-            ctx.connection_id, path
-        );
-
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await?;
-        file.write_all(data.as_ref()).await
     }
 
     async fn read_dir(
@@ -763,7 +766,7 @@ mod tests {
         let path = temp.child("missing-file").path().to_path_buf();
 
         let _ = api
-            .read_file(ctx, RemotePath::from(path))
+            .read_file(ctx, RemotePath::from(path), Default::default())
             .await
             .unwrap_err();
     }
@@ -777,38 +780,14 @@ mod tests {
         file.write_str("some file contents").unwrap();
 
         let bytes = api
-            .read_file(ctx, RemotePath::from(file.path().to_path_buf()))
+            .read_file(
+                ctx,
+                RemotePath::from(file.path().to_path_buf()),
+                Default::default(),
+            )
             .await
             .unwrap();
         assert_eq!(bytes, b"some file contents");
-    }
-
-    #[test(tokio::test)]
-    async fn read_file_text_should_send_error_if_fails_to_read_file() {
-        let (api, ctx, _rx) = setup().await;
-
-        let temp = assert_fs::TempDir::new().unwrap();
-        let path = temp.child("missing-file").path().to_path_buf();
-
-        let _ = api
-            .read_file_text(ctx, RemotePath::from(path))
-            .await
-            .unwrap_err();
-    }
-
-    #[test(tokio::test)]
-    async fn read_file_text_should_send_text_with_file_contents() {
-        let (api, ctx, _rx) = setup().await;
-
-        let temp = assert_fs::TempDir::new().unwrap();
-        let file = temp.child("test-file");
-        file.write_str("some file contents").unwrap();
-
-        let text = api
-            .read_file_text(ctx, RemotePath::from(file.path().to_path_buf()))
-            .await
-            .unwrap();
-        assert_eq!(text, "some file contents");
     }
 
     #[test(tokio::test)]
@@ -825,6 +804,7 @@ mod tests {
                 ctx,
                 RemotePath::from(file.path().to_path_buf()),
                 b"some text".to_vec(),
+                Default::default(),
             )
             .await
             .unwrap_err();
@@ -846,6 +826,7 @@ mod tests {
             ctx,
             RemotePath::from(file.path().to_path_buf()),
             b"some text".to_vec(),
+            Default::default(),
         )
         .await
         .unwrap();
@@ -856,7 +837,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn write_file_text_should_send_error_if_fails_to_write_file() {
+    async fn write_file_append_should_send_error_if_fails_to_create_file() {
         let (api, ctx, _rx) = setup().await;
 
         // Create a temporary path and add to it to ensure that there are
@@ -864,53 +845,14 @@ mod tests {
         let temp = assert_fs::TempDir::new().unwrap();
         let file = temp.child("dir").child("test-file");
 
-        api.write_file_text(
-            ctx,
-            RemotePath::from(file.path().to_path_buf()),
-            "some text".to_string(),
-        )
-        .await
-        .unwrap_err();
-
-        // Also verify that we didn't actually create the file
-        file.assert(predicate::path::missing());
-    }
-
-    #[test(tokio::test)]
-    async fn write_file_text_should_send_ok_when_successful() {
-        let (api, ctx, _rx) = setup().await;
-
-        // Path should point to a file that does not exist, but all
-        // other components leading up to it do
-        let temp = assert_fs::TempDir::new().unwrap();
-        let file = temp.child("test-file");
-
-        api.write_file_text(
-            ctx,
-            RemotePath::from(file.path().to_path_buf()),
-            "some text".to_string(),
-        )
-        .await
-        .unwrap();
-
-        // Also verify that we actually did create the file
-        // with the associated contents
-        file.assert("some text");
-    }
-
-    #[test(tokio::test)]
-    async fn append_file_should_send_error_if_fails_to_create_file() {
-        let (api, ctx, _rx) = setup().await;
-
-        // Create a temporary path and add to it to ensure that there are
-        // extra components that don't exist to cause writing to fail
-        let temp = assert_fs::TempDir::new().unwrap();
-        let file = temp.child("dir").child("test-file");
-
-        api.append_file(
+        api.write_file(
             ctx,
             RemotePath::from(file.path().to_path_buf()),
             b"some extra contents".to_vec(),
+            WriteFileOptions {
+                append: true,
+                ..Default::default()
+            },
         )
         .await
         .unwrap_err();
@@ -920,7 +862,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn append_file_should_create_file_if_missing() {
+    async fn write_file_append_should_create_file_if_missing() {
         let (api, ctx, _rx) = setup().await;
 
         // Don't create the file directly, but define path
@@ -928,10 +870,14 @@ mod tests {
         let temp = assert_fs::TempDir::new().unwrap();
         let file = temp.child("test-file");
 
-        api.append_file(
+        api.write_file(
             ctx,
             RemotePath::from(file.path().to_path_buf()),
             b"some extra contents".to_vec(),
+            WriteFileOptions {
+                append: true,
+                ..Default::default()
+            },
         )
         .await
         .unwrap();
@@ -944,7 +890,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn append_file_should_send_ok_when_successful() {
+    async fn write_file_append_should_send_ok_when_successful() {
         let (api, ctx, _rx) = setup().await;
 
         // Create a temporary file and fill it with some contents
@@ -952,80 +898,14 @@ mod tests {
         let file = temp.child("test-file");
         file.write_str("some file contents").unwrap();
 
-        api.append_file(
+        api.write_file(
             ctx,
             RemotePath::from(file.path().to_path_buf()),
             b"some extra contents".to_vec(),
-        )
-        .await
-        .unwrap();
-
-        // Yield to allow chance to finish appending to file
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Also verify that we actually did append to the file
-        file.assert("some file contentssome extra contents");
-    }
-
-    #[test(tokio::test)]
-    async fn append_file_text_should_send_error_if_fails_to_create_file() {
-        let (api, ctx, _rx) = setup().await;
-
-        // Create a temporary path and add to it to ensure that there are
-        // extra components that don't exist to cause writing to fail
-        let temp = assert_fs::TempDir::new().unwrap();
-        let file = temp.child("dir").child("test-file");
-
-        let _ = api
-            .append_file_text(
-                ctx,
-                RemotePath::from(file.path().to_path_buf()),
-                "some extra contents".to_string(),
-            )
-            .await
-            .unwrap_err();
-
-        // Also verify that we didn't actually create the file
-        file.assert(predicate::path::missing());
-    }
-
-    #[test(tokio::test)]
-    async fn append_file_text_should_create_file_if_missing() {
-        let (api, ctx, _rx) = setup().await;
-
-        // Don't create the file directly, but define path
-        // where the file should be
-        let temp = assert_fs::TempDir::new().unwrap();
-        let file = temp.child("test-file");
-
-        api.append_file_text(
-            ctx,
-            RemotePath::from(file.path().to_path_buf()),
-            "some extra contents".to_string(),
-        )
-        .await
-        .unwrap();
-
-        // Yield to allow chance to finish appending to file
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Also verify that we actually did create to the file
-        file.assert("some extra contents");
-    }
-
-    #[test(tokio::test)]
-    async fn append_file_text_should_send_ok_when_successful() {
-        let (api, ctx, _rx) = setup().await;
-
-        // Create a temporary file and fill it with some contents
-        let temp = assert_fs::TempDir::new().unwrap();
-        let file = temp.child("test-file");
-        file.write_str("some file contents").unwrap();
-
-        api.append_file_text(
-            ctx,
-            RemotePath::from(file.path().to_path_buf()),
-            "some extra contents".to_string(),
+            WriteFileOptions {
+                append: true,
+                ..Default::default()
+            },
         )
         .await
         .unwrap();

--- a/distant-host/tests/stress/distant/large_file.rs
+++ b/distant-host/tests/stress/distant/large_file.rs
@@ -35,7 +35,7 @@ async fn should_handle_large_files(#[future] ctx: ClientCtx) {
     // Perform the read
     eprintln!("Reading file using distant");
     let mut new_data = channel
-        .read_file(file.path().to_path_buf())
+        .read_file(file.path().to_path_buf(), Default::default())
         .await
         .expect("Failed to read large file");
     assert_eq!(new_data, data, "Data mismatch");
@@ -44,7 +44,11 @@ async fn should_handle_large_files(#[future] ctx: ClientCtx) {
     eprintln!("Writing file using distant");
     new_data[LARGE_FILE_LEN - 1] = new_data[LARGE_FILE_LEN - 1].overflowing_add(1).0;
     channel
-        .write_file(file.path().to_path_buf(), new_data.clone())
+        .write_file(
+            file.path().to_path_buf(),
+            new_data.clone(),
+            Default::default(),
+        )
         .await
         .expect("Failed to write large file");
     let data = tokio::fs::read(file.path())

--- a/distant-ssh/src/api.rs
+++ b/distant-ssh/src/api.rs
@@ -8,9 +8,9 @@ use async_once_cell::OnceCell;
 use distant_core::constants::{TUNNEL_CHANNEL_CAPACITY, TUNNEL_RELAY_BUFFER_SIZE};
 use distant_core::net::server::Reply;
 use distant_core::protocol::{
-    DirEntry, Environment, Metadata, PROTOCOL_VERSION, Permissions, ProcessId, PtySize, RemotePath,
-    Response, SearchId, SearchQuery, SetPermissionsOptions, StatusInfo, SystemInfo,
-    TunnelDirection, TunnelId, TunnelInfo, Version,
+    DirEntry, Environment, Metadata, PROTOCOL_VERSION, Permissions, ProcessId, PtySize,
+    ReadFileOptions, RemotePath, Response, SearchId, SearchQuery, SetPermissionsOptions,
+    StatusInfo, SystemInfo, TunnelDirection, TunnelId, TunnelInfo, Version, WriteFileOptions,
 };
 use distant_core::{Api, Ctx};
 use log::*;
@@ -230,39 +230,69 @@ impl SshApi {
     }
 }
 
+fn sftp_io_error(e: russh_sftp::client::error::Error, context: &str) -> io::Error {
+    use russh_sftp::client::error::Error as SftpError;
+    use russh_sftp::protocol::StatusCode;
+
+    let (kind, detail) = match &e {
+        SftpError::Status(status) => {
+            let kind = match status.status_code {
+                StatusCode::NoSuchFile => io::ErrorKind::NotFound,
+                StatusCode::PermissionDenied => io::ErrorKind::PermissionDenied,
+                StatusCode::OpUnsupported => io::ErrorKind::Unsupported,
+                StatusCode::Eof => io::ErrorKind::UnexpectedEof,
+                _ => io::ErrorKind::Other,
+            };
+            (
+                kind,
+                format!("{}: {}", status.status_code, status.error_message),
+            )
+        }
+        SftpError::Timeout => (io::ErrorKind::TimedOut, e.to_string()),
+        SftpError::IO(msg) => (io::ErrorKind::Other, msg.clone()),
+        _ => (io::ErrorKind::Other, e.to_string()),
+    };
+
+    io::Error::new(kind, format!("{context}: {detail}"))
+}
+
 impl Api for SshApi {
     fn read_file(
         &self,
         ctx: Ctx,
         path: RemotePath,
+        options: ReadFileOptions,
     ) -> impl Future<Output = io::Result<Vec<u8>>> + Send {
         let sftp_path = self.sftp_path(&path);
         async move {
-            debug!("[Conn {}] Reading file {}", ctx.connection_id, path);
+            debug!(
+                "[Conn {}] Reading file {} (options: {:?})",
+                ctx.connection_id, path, options
+            );
 
             let sftp = self.get_sftp().await?;
 
-            use tokio::io::AsyncReadExt;
+            use tokio::io::{AsyncReadExt, AsyncSeekExt};
             let mut file = sftp
                 .open(sftp_path.as_str())
                 .await
-                .map_err(|e| io::Error::other(format!("SFTP open '{}': {e}", sftp_path)))?;
+                .map_err(|e| sftp_io_error(e, &format!("SFTP open '{}'", sftp_path)))?;
+
+            if let Some(offset) = options.offset {
+                file.seek(io::SeekFrom::Start(offset)).await?;
+            }
 
             let mut contents = Vec::new();
-            file.read_to_end(&mut contents).await?;
+            match options.len {
+                Some(len) => {
+                    file.take(len).read_to_end(&mut contents).await?;
+                }
+                None => {
+                    file.read_to_end(&mut contents).await?;
+                }
+            }
 
             Ok(contents)
-        }
-    }
-
-    fn read_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-    ) -> impl Future<Output = io::Result<String>> + Send {
-        async move {
-            let data = self.read_file(ctx, path).await?;
-            String::from_utf8(data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
         }
     }
 
@@ -271,74 +301,60 @@ impl Api for SshApi {
         ctx: Ctx,
         path: RemotePath,
         data: Vec<u8>,
+        options: WriteFileOptions,
     ) -> impl Future<Output = io::Result<()>> + Send {
         let sftp_path = self.sftp_path(&path);
         async move {
-            debug!("[Conn {}] Writing file {}", ctx.connection_id, path);
-
-            let sftp = self.get_sftp().await?;
-
-            use tokio::io::AsyncWriteExt;
-            let mut file = sftp
-                .create(sftp_path.as_str())
-                .await
-                .map_err(|e| io::Error::other(format!("SFTP create '{}': {e}", sftp_path)))?;
-
-            file.write_all(&data).await?;
-            file.flush().await?;
-
-            Ok(())
-        }
-    }
-
-    fn write_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: String,
-    ) -> impl Future<Output = io::Result<()>> + Send {
-        async move { self.write_file(ctx, path, data.into_bytes()).await }
-    }
-
-    fn append_file(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: Vec<u8>,
-    ) -> impl Future<Output = io::Result<()>> + Send {
-        let sftp_path = self.sftp_path(&path);
-        async move {
-            debug!("[Conn {}] Appending to file {}", ctx.connection_id, path);
+            debug!(
+                "[Conn {}] Writing file {} (options: {:?})",
+                ctx.connection_id, path, options
+            );
 
             let sftp = self.get_sftp().await?;
 
             use russh_sftp::protocol::OpenFlags;
-            use tokio::io::AsyncWriteExt;
+            use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+
+            if options.append {
+                let mut file = sftp
+                    .open_with_flags(
+                        sftp_path.as_str(),
+                        OpenFlags::WRITE | OpenFlags::CREATE | OpenFlags::APPEND,
+                    )
+                    .await
+                    .map_err(|e| {
+                        sftp_io_error(e, &format!("SFTP open_with_flags '{}'", sftp_path))
+                    })?;
+
+                file.write_all(&data).await?;
+                file.flush().await?;
+                return Ok(());
+            }
+
+            if let Some(offset) = options.offset {
+                let mut file = sftp
+                    .open_with_flags(sftp_path.as_str(), OpenFlags::WRITE | OpenFlags::CREATE)
+                    .await
+                    .map_err(|e| {
+                        sftp_io_error(e, &format!("SFTP open_with_flags '{}'", sftp_path))
+                    })?;
+
+                file.seek(io::SeekFrom::Start(offset)).await?;
+                file.write_all(&data).await?;
+                file.flush().await?;
+                return Ok(());
+            }
 
             let mut file = sftp
-                .open_with_flags(
-                    sftp_path.as_str(),
-                    OpenFlags::WRITE | OpenFlags::CREATE | OpenFlags::APPEND,
-                )
+                .create(sftp_path.as_str())
                 .await
-                .map_err(|e| {
-                    io::Error::other(format!("SFTP open_with_flags '{}': {e}", sftp_path))
-                })?;
+                .map_err(|e| sftp_io_error(e, &format!("SFTP create '{}'", sftp_path)))?;
 
             file.write_all(&data).await?;
             file.flush().await?;
 
             Ok(())
         }
-    }
-
-    fn append_file_text(
-        &self,
-        ctx: Ctx,
-        path: RemotePath,
-        data: String,
-    ) -> impl Future<Output = io::Result<()>> + Send {
-        async move { self.append_file(ctx, path, data.into_bytes()).await }
     }
 
     fn read_dir(

--- a/distant-ssh/src/config.rs
+++ b/distant-ssh/src/config.rs
@@ -355,16 +355,11 @@ fn parse_ssh_g_output(output: &str) -> Option<ResolvedConfig> {
             "identityfile" => {
                 identity_files.push(PathBuf::from(value));
             }
-            "proxycommand" => {
-                if !value.eq_ignore_ascii_case("none") {
-                    config.proxy_command = Some(value.to_string());
-                }
+            "proxycommand" if !value.eq_ignore_ascii_case("none") => {
+                config.proxy_command = Some(value.to_string());
             }
-            "proxyjump" => {
-                if !value.eq_ignore_ascii_case("none") {
-                    config.proxy_jump =
-                        Some(value.split(',').map(|s| s.trim().to_string()).collect());
-                }
+            "proxyjump" if !value.eq_ignore_ascii_case("none") => {
+                config.proxy_jump = Some(value.split(',').map(|s| s.trim().to_string()).collect());
             }
             "identitiesonly" => {
                 config.identities_only = Some(value.to_string());
@@ -417,10 +412,8 @@ fn parse_ssh_g_output(output: &str) -> Option<ResolvedConfig> {
                 config.pubkey_accepted_algorithms =
                     value.split(',').map(|s| s.trim().to_string()).collect();
             }
-            "identityagent" => {
-                if !value.eq_ignore_ascii_case("none") {
-                    config.identity_agent = Some(value.to_string());
-                }
+            "identityagent" if !value.eq_ignore_ascii_case("none") => {
+                config.identity_agent = Some(value.to_string());
             }
             _ => {
                 // Ignore other fields

--- a/distant-ssh/tests/ssh/client.rs
+++ b/distant-ssh/tests/ssh/client.rs
@@ -50,7 +50,10 @@ async fn read_file_should_fail_if_file_missing(#[future] client: Ctx<Client>) {
     let temp = assert_fs::TempDir::new().unwrap();
     let path = temp.child("missing-file").path().to_path_buf();
 
-    let _ = client.read_file(path).await.unwrap_err();
+    let _ = client
+        .read_file(path, Default::default())
+        .await
+        .unwrap_err();
 }
 
 #[rstest]
@@ -62,7 +65,10 @@ async fn read_file_should_send_blob_with_file_contents(#[future] client: Ctx<Cli
     let file = temp.child("test-file");
     file.write_str("some file contents").unwrap();
 
-    let bytes = client.read_file(file.path().to_path_buf()).await.unwrap();
+    let bytes = client
+        .read_file(file.path().to_path_buf(), Default::default())
+        .await
+        .unwrap();
     assert_eq!(bytes, b"some file contents");
 }
 
@@ -124,7 +130,11 @@ async fn write_file_should_send_error_if_fails_to_write_file(#[future] client: C
     let file = temp.child("dir").child("test-file");
 
     let _ = client
-        .write_file(file.path().to_path_buf(), b"some text".to_vec())
+        .write_file(
+            file.path().to_path_buf(),
+            b"some text".to_vec(),
+            Default::default(),
+        )
         .await
         .unwrap_err();
 
@@ -143,7 +153,11 @@ async fn write_file_should_send_ok_when_successful(#[future] client: Ctx<Client>
     let file = temp.child("test-file");
 
     client
-        .write_file(file.path().to_path_buf(), b"some text".to_vec())
+        .write_file(
+            file.path().to_path_buf(),
+            b"some text".to_vec(),
+            Default::default(),
+        )
         .await
         .unwrap();
 

--- a/docs/superpowers/specs/2026-04-16-file-mount-decomposition-design.md
+++ b/docs/superpowers/specs/2026-04-16-file-mount-decomposition-design.md
@@ -1,0 +1,291 @@
+# File Mount Branch Decomposition — Design Spec
+
+**Date:** 2026-04-16
+**Status:** Approved
+**Branch:** `feature/file-mount` (60+ commits ahead of master, 130 files, +24.5k lines)
+
+## Context
+
+The `feature/file-mount` branch adds `distant-mount` crate with 4 mount
+backends (FUSE, NFS, macOS FileProvider, Windows Cloud Files), manager-owned
+mount lifecycle, network resilience/reconnection, health monitoring, and a
+comprehensive rstest-based test suite. The branch compiles clean with zero
+stubs and zero merge conflicts with master.
+
+The previous AI development process spiraled into 197 commits due to
+whack-a-mole regressions, scope creep, and slow cross-platform verification.
+This spec decomposes the branch into reviewable phases that each independently
+compile and test, with the test framework introduced early so each backend
+adds rstest cases as it lands.
+
+**Chosen approach:** "Foundation First" — decompose into phased PRs, each
+with clear completion criteria.
+
+---
+
+## Baseline Stabilization (Pre-Requisite)
+
+- Investigate TD-3 (ProcDone/ProcStdout race) before coding — check git
+  history for prior attempts, understand cross-platform differences
+- If protocol-level fix is hard, make test assertions more resilient instead
+- Time-box to one focused session; don't let it spiral
+- Add CI flakiness visibility (report which tests needed retries) regardless
+- 7/13 recent "green" CI runs had flaky tests masked by retries — all
+  process-spawn/stdout-capture related
+
+---
+
+## Phase Decomposition
+
+### Overview
+
+8 phases (with Phase 3 sub-split into 3a/3b). The test framework enters at
+Phase 4 as a skeleton with zero rstest cases. Each subsequent backend phase
+adds its `#[case::...]` annotations, so tests grow incrementally.
+
+```
+Phase 1 (protocol) → Phase 2 (net resilience) → Phase 3a (events) → Phase 3b (mount lifecycle)
+                                                                          ↓
+                                              Phase 4 (mount crate + CLI + test skeleton)
+                                                                          ↓
+                                              Phase 5 (NFS + first rstest cases)
+                                                    ↓               ↓              ↓
+                                              Phase 6 (FUSE)  Phase 7 (FP)  Phase 8 (WCF)
+```
+
+Phases 6, 7, and 8 are independent of each other once Phase 5 lands.
+
+---
+
+### Phase 1: Protocol Consolidation (~1,200 lines)
+
+Collapse `FileRead`/`FileReadText`/`FileWrite`/`FileWriteText`/
+`FileAppend`/`FileAppendText` into `FileRead` + `FileWrite` with
+`ReadFileOptions`/`WriteFileOptions`. Plus `Msg<T>` custom Deserialize
+(wire-protocol error visibility) and `hex_preview` utility.
+
+**Files:**
+- `distant-core/src/protocol/request.rs` — variant consolidation
+- `distant-core/src/protocol/common/file_options.rs` — new option types
+- `distant-core/src/protocol/msg.rs` — custom Deserialize for Msg<T>
+- `distant-core/src/api.rs`, `distant-core/src/client/ext.rs` — updated signatures
+- `distant-core/src/net/common/utils.rs` — hex_preview
+- `distant-host/src/api.rs`, `distant-ssh/src/api.rs`, `distant-docker/src/api.rs`
+- `distant-core/tests/api_tests.rs`
+
+**Done when:** `cargo clippy --all-features --workspace` clean, all existing
+tests pass, no wire format regressions.
+
+---
+
+### Phase 2: Network Resilience Primitives (~1,100 lines)
+
+TCP keepalive (`TcpTransport::set_keepalive`), heartbeat failure escalation
+(`max_heartbeat_failures`), `ReconnectStrategy` variants, `ConnectionWatcher`
+improvements, `Plugin::reconnect` + `reconnect_strategy` trait extensions
+with default impls. Backend implementations for host/ssh/docker.
+
+**Files:**
+- `distant-core/src/net/common/transport/tcp.rs` — keepalive
+- `distant-core/src/net/server/config.rs` — heartbeat config
+- `distant-core/src/net/server/connection.rs`, `ref.rs` — heartbeat escalation
+- `distant-core/src/net/client/reconnect.rs` — strategy types, ConnectionWatcher
+- `distant-core/src/net/client/channel.rs` — hex_preview on decode errors
+- `distant-core/src/net/common/map.rs` — Map utility
+- `distant-core/src/plugin/mod.rs` — reconnect + reconnect_strategy
+- `distant-host/src/plugin.rs`, `distant-ssh/src/plugin.rs`, `distant-docker/src/plugin.rs`
+
+**Done when:** All existing tests pass. Reconnect trait methods have unit tests.
+
+---
+
+### Phase 3a: Event Infrastructure + Manager Resilience (~1,200 lines)
+
+Generic event/subscribe system. `EventTopic`, `Event` (with
+`ConnectionState` only — no mount variants yet), `Subscribe`/`Unsubscribe`/
+`Reconnect` request/response variants, event broadcast bus in manager,
+manager reconnection orchestration, `ConnectionWatcher` integration.
+
+**Files:**
+- `distant-core/src/net/manager/data/event.rs` — EventTopic, Event (ConnectionState only)
+- `distant-core/src/net/manager/data/request.rs` — Subscribe, Unsubscribe, Reconnect
+- `distant-core/src/net/manager/data/response.rs` — Subscribed, Unsubscribed, Event, ReconnectInitiated
+- `distant-core/src/net/manager/server.rs` — event_tx, subscribe/reconnect handlers
+- `distant-core/src/net/manager/server/connection.rs` — reconnection orchestration
+- `distant-core/src/net/manager/client.rs` — subscribe/reconnect client methods
+- `src/cli/commands/client.rs` — subscribe_and_display_events, reconnect command
+- `src/options.rs` — --no-reconnect, --heartbeat-interval, --max-heartbeat-failures
+
+**Done when:** Can subscribe to connection state events via CLI. Unit tests
+for event serde round-trips.
+
+---
+
+### Phase 3b: Mount Lifecycle in Manager (~1,500 lines)
+
+Mount protocol types, `MountPlugin`/`MountHandle`/`MountProbe` traits,
+manager mount/unmount handlers, `ManagedMount` struct, `Event::MountState`
+variant, `monitor_mount` health task, `ResourceKind` for unified List
+filtering, manager client mount/unmount methods.
+
+**Files:**
+- `distant-core/src/protocol/mount.rs` — MountConfig, CacheConfig, MountInfo, MountStatus, ResourceKind
+- `distant-core/src/plugin/mount.rs` — MountPlugin, MountHandle, MountProbe
+- `distant-core/src/net/manager/data/event.rs` — add Event::MountState variant
+- `distant-core/src/net/manager/data/request.rs` — Mount, Unmount variants
+- `distant-core/src/net/manager/data/response.rs` — Mounted, Unmounted, Mounts variants
+- `distant-core/src/net/manager/server.rs` — ManagedMount, mount/unmount handlers, monitor_mount
+- `distant-core/src/net/manager/server/config.rs` — mount_plugins, mount_health_interval
+- `distant-core/src/net/manager/client.rs` — mount/unmount client methods
+
+**Done when:** Unit tests for MountConfig/MountInfo serde, MountPlugin mock
+round-trip, mount/unmount via manager with ScriptedMountHandle. Clippy clean.
+
+---
+
+### Phase 4: distant-mount Crate + CLI + Test Framework Skeleton (~3,500 lines)
+
+New `distant-mount` workspace member with core abstractions (RemoteFs,
+InodeTable, cache, buffer, handle, runtime), `MountBackend` enum, backend
+trait — NO backend implementations. CLI `distant mount`/`distant unmount`/
+`distant status --show mount`. Test harness: `MountProcess`, singleton mount
+infrastructure, rstest_reuse template with zero `#[case]` annotations.
+
+**Files:**
+- `distant-mount/` — crate skeleton (Cargo.toml, src/lib.rs, src/core/*, src/backend/mod.rs, src/plugin.rs)
+- `Cargo.toml` — workspace member addition
+- `src/options.rs` — mount/unmount/status CLI options
+- `src/cli/commands/client.rs` — mount/unmount/status handlers
+- `src/cli/common/client.rs`, `src/cli/common/manager.rs` — mount client helpers
+- `src/constants.rs` — mount-related constants
+- `distant-test-harness/Cargo.toml` — mount feature, distant-mount dependency
+- `distant-test-harness/src/mount.rs` — MountProcess, wait helpers, singleton mounts
+- `distant-test-harness/src/singleton.rs` — singleton server + mount infrastructure
+- `tests/cli/mount/mod.rs` — rstest_reuse template (zero cases)
+- `tests/cli/mount/*.rs` — test files (compile but produce zero tests)
+
+**Done when:** Clippy clean. `distant mount` CLI exists and returns "no
+backend" error. Test template compiles with zero cases. `cargo test` passes.
+
+---
+
+### Phase 5: NFS Backend + First rstest Cases (~600 lines)
+
+NFS backend (in-process NFS server + os_mount), NFS mount plugin. Add
+`#[case::host_nfs]`, `#[case::ssh_nfs]`, `#[case::docker_nfs]` to rstest
+template. **First phase where mount tests execute.**
+
+**Files:**
+- `distant-mount/src/backend/nfs.rs`
+- `distant-mount/src/plugin.rs` — NfsMountPlugin
+- `tests/cli/mount/mod.rs` — add NFS case annotations
+- `src/cli/commands/manager.rs` — register NFS mount plugin
+
+**Done when:** NFS rstest cases pass for host, ssh, and docker. Full suite green.
+
+---
+
+### Phase 6: FUSE Backend + rstest Cases (~500 lines)
+
+FUSE backend (fuser::spawn_mount2), FUSE mount plugin. Add
+`#[case::host_fuse]`, `#[case::ssh_fuse]` to rstest template.
+
+**Files:**
+- `distant-mount/src/backend/fuse.rs`
+- `distant-mount/src/plugin.rs` — FuseMountPlugin
+- `tests/cli/mount/mod.rs` — add FUSE case annotations
+- `src/cli/commands/manager.rs` — register FUSE mount plugin
+
+**Done when:** FUSE rstest cases pass for host and ssh backends.
+
+---
+
+### Phase 7: macOS FileProvider Backend + rstest Cases (~2,300 lines)
+
+FileProvider backend with provider/enumerator/item hierarchy, `macos_appex`
+binary, provisioning profiles, build scripts, FP-specific test helpers.
+Add `#[case::host_file_provider]` to rstest template.
+
+**Files:**
+- `distant-mount/src/backend/macos_file_provider.rs` + subdirectory
+- `distant-mount/src/plugin.rs` — FileProviderMountPlugin
+- `src/macos_appex.rs`, `src/main.rs`, `resources/macos/`, `scripts/`
+- `distant-test-harness/src/singleton.rs` — FP singleton
+- `distant-test-harness/src/mount.rs` — FP-specific helpers
+- `tests/cli/mount/mod.rs` — add FP case annotations
+
+**Done when:** FP rstest cases pass on macOS. Manual verification in Finder.
+
+---
+
+### Phase 8: Windows Cloud Files Backend + rstest Cases (~1,700 lines)
+
+CfApi-based Windows sync root implementation. Add
+`#[case::host_windows_cloud_files]` to rstest template.
+
+**Files:**
+- `distant-mount/src/backend/windows_cloud_files.rs`
+- `distant-mount/src/plugin.rs` — CloudFilesMountPlugin
+- `tests/cli/mount/mod.rs` — add WCF case annotations
+- `src/cli/commands/manager.rs` — register WCF mount plugin
+
+**Done when:** WCF rstest cases pass on Windows VM.
+
+---
+
+## AI Dev Process Guardrails
+
+### Rule 1: Scope Lock Per Phase
+Scope frozen to file list in plan. Out-of-scope → `docs/TODO.md` or issue.
+
+### Rule 2: Autonomous Work with Clean History
+AI works autonomously. `cargo fmt + clippy + test` before each commit. May
+rebase/amend within current phase.
+
+**Hard stops:** public API/trait changes, phase completion gate, 2 failed
+fix attempts.
+
+### Rule 3: No Stacking on Red
+Tests fail → fix first. 2 failed attempts → escalate. Never commit broken code.
+
+### Rule 4: Maximum Commit Budget
+Soft 10 / hard 15 per phase. Phase 4: soft 12 / hard 18.
+
+### Rule 5: Windows VM On-Demand
+Phases 1–3b, 5–6: no VM. Phase 4: compilation check at end. Phase 8: VM at start.
+
+### Rule 6: Code Quality Gate
+`code-validator` agent on every commit. No stubs. Blocking issues must be fixed.
+
+### Rule 7: Phase Completion Protocol
+1. `cargo clippy --all-features --workspace --all-targets` clean
+2. `cargo nextest run --all-features --workspace --all-targets` green
+3. Confirm only expected files touched
+4. User reviews PR on GitHub before merge
+5. Next phase on fresh branch from updated master
+
+---
+
+## Test Reliability
+
+### Singleton Decision
+Master uses per-test ephemeral contexts. Branch introduced singletons as a
+**performance optimization** (not a technical requirement — FP tests worked
+per-test, just slowly). Keep singletons: PID liveness checks, `--shutdown
+lonely=30`, unique subdirs, file-lock coordination. Fall back to per-test
+if problems arise.
+
+### Rules
+- **Poll, don't sleep** — `wait_for_path()`, `wait_until_exists()`, etc.
+- **Unique subdirs** — each test gets its own remote directory
+- **Hold singleton handles** — name `_sm` or `sm`, never `_`
+- **No retry-as-crutch** — NFS/FUSE failures are bugs; FP gets longer
+  poll timeouts; WCF gets longer nextest timeouts
+
+### Per-Phase Risk
+| Phase | Backend | Risk |
+|-------|---------|------|
+| 5 | NFS | Low — deterministic |
+| 6 | FUSE | Low — similar to NFS |
+| 7 | FileProvider | High — materialization timing, appex lifecycle |
+| 8 | Cloud Files | High — slow VM |

--- a/src/cli/commands/client.rs
+++ b/src/cli/commands/client.rs
@@ -862,6 +862,7 @@ async fn async_run(cmd: ClientSubcommand, quiet: bool) -> CliResult {
                 .send(protocol::Msg::Batch(vec![
                     protocol::Request::FileRead {
                         path: RemotePath::from(path.as_path()),
+                        options: Default::default(),
                     },
                     protocol::Request::DirRead {
                         path: RemotePath::from(path.as_path()),
@@ -1131,7 +1132,7 @@ async fn async_run(cmd: ClientSubcommand, quiet: bool) -> CliResult {
                 channel
                     .into_client()
                     .into_channel()
-                    .write_file(path.as_path(), data)
+                    .write_file(path.as_path(), data, Default::default())
                     .await
                     .with_context(|| {
                         format!("Failed to write to {path:?} using connection {connection_id}")

--- a/src/cli/commands/client/copy.rs
+++ b/src/cli/commands/client/copy.rs
@@ -206,7 +206,7 @@ async fn upload_file(
     let sp = ui.spinner(&format!("Uploading {name} ({})...", format_bytes(size)));
 
     channel
-        .write_file(RemotePath::new(remote.as_str()), data)
+        .write_file(RemotePath::new(remote.as_str()), data, Default::default())
         .await
         .with_context(|| format!("Failed to write remote file {}", remote.as_str()))?;
 
@@ -236,7 +236,7 @@ async fn download_file(
     ));
 
     let data = channel
-        .read_file(RemotePath::new(remote.as_str()))
+        .read_file(RemotePath::new(remote.as_str()), Default::default())
         .await
         .with_context(|| format!("Failed to read remote file {}", remote.as_str()))?;
 
@@ -355,7 +355,11 @@ async fn upload_dir(
         total_size += data.len() as u64;
 
         channel
-            .write_file(RemotePath::new(remote_file.as_str()), data)
+            .write_file(
+                RemotePath::new(remote_file.as_str()),
+                data,
+                Default::default(),
+            )
             .await
             .with_context(|| format!("Failed to write remote file {}", remote_file.as_str()))?;
 
@@ -456,7 +460,7 @@ async fn download_dir(
         // Build full remote path from base + relative entry path
         let remote_file = remote.join(file_entry.path.as_str());
         let data = channel
-            .read_file(RemotePath::new(remote_file.as_str()))
+            .read_file(RemotePath::new(remote_file.as_str()), Default::default())
             .await
             .with_context(|| format!("Failed to read remote file {}", file_entry.path))?;
         total_size += data.len() as u64;

--- a/tests/cli/api/file_append.rs
+++ b/tests/cli/api/file_append.rs
@@ -1,4 +1,5 @@
-//! Integration tests for the `file_append` (binary/byte) JSON API endpoint.
+//! Integration tests for appending binary data via the `file_write` JSON API endpoint
+//! with `append: true` in the options.
 //!
 //! Tests appending raw byte data to an existing file and error handling
 //! when the target file's parent directory is missing.
@@ -34,9 +35,12 @@ async fn should_support_json_output(mut api_process: CtxCommand<ApiProcess>) {
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_append",
+            "type": "file_write",
             "path": file.to_path_buf(),
             "data": APPENDED_FILE_CONTENTS.as_bytes().to_vec(),
+            "options": {
+                "append": true
+            },
         },
     });
 
@@ -70,9 +74,12 @@ async fn should_support_json_output_for_error(mut api_process: CtxCommand<ApiPro
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_append",
+            "type": "file_write",
             "path": file.to_path_buf(),
             "data": APPENDED_FILE_CONTENTS.as_bytes().to_vec(),
+            "options": {
+                "append": true
+            },
         },
     });
 

--- a/tests/cli/api/file_append_text.rs
+++ b/tests/cli/api/file_append_text.rs
@@ -1,6 +1,7 @@
-//! Integration tests for the `file_append_text` JSON API endpoint.
+//! Integration tests for appending text content via the `file_write` JSON API endpoint
+//! with `append: true` in the options.
 //!
-//! Tests appending text content to an existing file and error handling
+//! Tests appending byte data (converted from text) to an existing file and error handling
 //! when the target file's parent directory is missing.
 
 use assert_fs::prelude::*;
@@ -34,9 +35,12 @@ async fn should_support_json_output(mut api_process: CtxCommand<ApiProcess>) {
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_append_text",
+            "type": "file_write",
             "path": file.to_path_buf(),
-            "text": APPENDED_FILE_CONTENTS.to_string(),
+            "data": APPENDED_FILE_CONTENTS.as_bytes().to_vec(),
+            "options": {
+                "append": true
+            },
         },
     });
 
@@ -70,9 +74,12 @@ async fn should_support_json_output_for_error(mut api_process: CtxCommand<ApiPro
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_append_text",
+            "type": "file_write",
             "path": file.to_path_buf(),
-            "text": APPENDED_FILE_CONTENTS.to_string(),
+            "data": APPENDED_FILE_CONTENTS.as_bytes().to_vec(),
+            "options": {
+                "append": true
+            },
         },
     });
 

--- a/tests/cli/api/file_read_text.rs
+++ b/tests/cli/api/file_read_text.rs
@@ -1,6 +1,7 @@
-//! Integration tests for the `file_read_text` JSON API endpoint.
+//! Integration tests for reading a file as text via the `file_read` JSON API endpoint.
 //!
-//! Tests reading a file as text and error handling when the file does not exist.
+//! Tests reading a file as raw bytes (the text convenience variants have been removed
+//! from the protocol) and error handling when the file does not exist.
 
 use assert_fs::prelude::*;
 use rstest::*;
@@ -28,7 +29,7 @@ async fn should_support_json_output(mut api_process: CtxCommand<ApiProcess>) {
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_read_text",
+            "type": "file_read",
             "path": file.to_path_buf(),
         },
     });
@@ -39,8 +40,8 @@ async fn should_support_json_output(mut api_process: CtxCommand<ApiProcess>) {
     assert_eq!(
         res["payload"],
         json!({
-            "type": "text",
-            "data": FILE_CONTENTS.to_string()
+            "type": "blob",
+            "data": FILE_CONTENTS.as_bytes().to_vec()
         }),
         "JSON: {res}"
     );
@@ -58,7 +59,7 @@ async fn should_support_json_output_for_error(mut api_process: CtxCommand<ApiPro
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_read_text",
+            "type": "file_read",
             "path": file.to_path_buf(),
         },
     });

--- a/tests/cli/api/file_write_text.rs
+++ b/tests/cli/api/file_write_text.rs
@@ -1,7 +1,8 @@
-//! Integration tests for the `file_write_text` JSON API endpoint.
+//! Integration tests for writing text content via the `file_write` JSON API endpoint.
 //!
-//! Tests writing text content to a file and error handling when the target
-//! file's parent directory is missing.
+//! Tests writing byte data (converted from text) to a file and error handling when
+//! the target file's parent directory is missing. The text convenience variants have
+//! been removed from the protocol.
 
 use assert_fs::prelude::*;
 use rstest::*;
@@ -28,9 +29,9 @@ async fn should_support_json_output(mut api_process: CtxCommand<ApiProcess>) {
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_write_text",
+            "type": "file_write",
             "path": file.to_path_buf(),
-            "text": FILE_CONTENTS.to_string(),
+            "data": FILE_CONTENTS.as_bytes().to_vec(),
         },
     });
 
@@ -64,9 +65,9 @@ async fn should_support_json_output_for_error(mut api_process: CtxCommand<ApiPro
     let req = json!({
         "id": id,
         "payload": {
-            "type": "file_write_text",
+            "type": "file_write",
             "path": file.to_path_buf(),
-            "text": FILE_CONTENTS.to_string(),
+            "data": FILE_CONTENTS.as_bytes().to_vec(),
         },
     });
 


### PR DESCRIPTION
## Summary
- Collapse FileRead/FileReadText/FileWrite/FileWriteText/FileAppend/FileAppendText into FileRead + FileWrite with ReadFileOptions/WriteFileOptions
- Custom Msg<T> Deserialize that preserves inner errors instead of collapsing to "did not match any variant"
- hex_preview utility for binary-safe error logging of wire payloads
- All backends (host, ssh, docker) updated with offset/len/append support

## Part of
Phase 1 of the file-mount branch decomposition. See docs/superpowers/specs/2026-04-16-file-mount-decomposition-design.md

## Test plan
- [x] All existing tests pass (protocol consolidation is backwards-compatible via `#[serde(default)]`)
- [x] New option-specific serde round-trip tests (ReadFileOptions, WriteFileOptions)
- [x] Msg<T> failure_paths tests verify inner error propagation
- [x] hex_preview unit tests
- [x] Full workspace clippy + test clean (426 passed, 0 failed)